### PR TITLE
1284: Added PethPrefix scope to traefik rules to allow co-hosting with legacy eventdb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ See [keep a changelog] for information about writing changes to this log.
 - Sort response
 - Update composer dependencies
 - Added api-key auth
+- Added PethPrefix scope to traefik rules to allow co-hosting with legacy eventdb
 
 [keep a changelog]: https://keepachangelog.com/en/1.1.0/
 [unreleased]: https://github.com/itk-dev/event-database-imports/compare/main...develop

--- a/docker-compose.server.override.yml
+++ b/docker-compose.server.override.yml
@@ -1,0 +1,17 @@
+# itk-version: 3.2.0
+
+networks:
+  frontend:
+    external: true
+  app:
+    driver: bridge
+    internal: false
+
+services:
+  nginx:
+    labels:
+      # Scope hosting by path prefix to allow shared hosting with legacy EventDB
+      # 'https://api.detskeriaarhus.dk/api/' -> Legacy EventDB
+      # 'https://api.detskeriaarhus.dk/api/v2/' -> EventDB v2
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}-http.rule=Host(`${COMPOSE_SERVER_DOMAIN}`) && PathPrefix(`${APP_PATH_PREFIX}`)"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_SERVER_DOMAIN}`) && PathPrefix(`${APP_PATH_PREFIX}`)"


### PR DESCRIPTION
#### Link to ticket

https://leantime.itkdev.dk/tickets/showKanban?tab=timesheet#/tickets/showTicket/1284

#### Description

Added PethPrefix scope to traefik rules to allow co-hosting with legacy eventdb

#### Screenshot of the result

If your change affects the user interface you should include a screenshot of the result with the pull request.

#### Checklist

- [ ] My code is covered by test cases.
- [ ] My code passes our test (all our tests).
- [ ] My code passes our static analysis suite.
- [ ] My code passes our continuous integration process.

If your code does not pass all the requirements on the checklist you have to add a comment explaining why this change 
should be exempt from the list.

#### Additional comments or questions

If you have any further comments or questions for the reviewer please add them here.
