### PR TITLE
4268: Use built-in match filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-20](https://github.com/itk-dev/event-database-api/pull/20)
+  - Used built-in match filter
 - [PR-21](https://github.com/itk-dev/event-database-api/pull/21)
   Linted YAML
 - [PR-18](https://github.com/itk-dev/event-database-api/pull/18)

--- a/src/Api/Dto/Event.php
+++ b/src/Api/Dto/Event.php
@@ -2,6 +2,7 @@
 
 namespace App\Api\Dto;
 
+use ApiPlatform\Elasticsearch\Filter\MatchFilter;
 use ApiPlatform\Metadata\ApiFilter;
 use ApiPlatform\Metadata\ApiProperty;
 use ApiPlatform\Metadata\ApiResource;
@@ -13,7 +14,6 @@ use ApiPlatform\OpenApi\Model\Response;
 use App\Api\Filter\ElasticSearch\BooleanFilter;
 use App\Api\Filter\ElasticSearch\DateRangeFilter;
 use App\Api\Filter\ElasticSearch\IdFilter;
-use App\Api\Filter\ElasticSearch\MatchFilter;
 use App\Api\Filter\ElasticSearch\TagFilter;
 use App\Api\State\EventRepresentationProvider;
 use App\Model\DateLimit;

--- a/tests/ApiPlatform/EventsFilterTest.php
+++ b/tests/ApiPlatform/EventsFilterTest.php
@@ -140,5 +140,19 @@ class EventsFilterTest extends AbstractApiTestCase
             1,
             'Events in 2026 tagged with "itkdev"',
         ];
+
+        yield [
+            [
+                'title' => 'cykel',
+            ],
+            0,
+        ];
+
+        yield [
+            [
+                'title' => 'bicycle',
+            ],
+            1,
+        ];
     }
 }

--- a/tests/resources/events.json
+++ b/tests/resources/events.json
@@ -169,7 +169,7 @@
     }
 },{
     "entityId": 9,
-    "title": "ITKDev test event 2",
+    "title": "ITKDev test event bicycle",
     "excerpt": "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.",
     "description": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Quis blandit turpis cursus in. Nisl suscipit adipiscing bibendum est ultricies integer quis auctor. Diam donec adipiscing tristique risus nec feugiat. Tincidunt eget nullam non nisi est. Consectetur a erat nam at lectus urna. Vulputate sapien nec sagittis aliquam. Luctus venenatis lectus magna fringilla. Sit amet consectetur adipiscing elit duis tristique. Bibendum enim facilisis gravida neque convallis a.<\/p><p>Cursus eget nunc scelerisque viverra mauris in aliquam sem. Euismod elementum nisi quis eleifend quam adipiscing vitae proin sagittis.<br \/>Sodales ut eu sem integer vitae justo eget. Lacus sed viverra tellus in.<\/p>",
     "url": "https:\/\/itk.aarhus.dk\/nyheder\/projektnyheder\/robotternes-bidrag-til-den-groenne-omstilling\/",


### PR DESCRIPTION
Builds on https://github.com/itk-dev/event-database-api/pull/18 to use built-in Elasticsearch filter.

> [!IMPORTANT]
> We'll leave this for now. The current custom filters make some assumptions on entity names and such, and we need more time to resolve this. The custom filters are not very complex, i.e. we don't have a lot of techincal dept hidden in them, and therefore it makes sense (from a security point of view) to postpone a potential cleanup to when/if time – and money – allows putting more effort into this.
