### PR TITLE
chore: adapt Claude Code setup from event-database-imports

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -89,52 +89,63 @@
             "statusMessage": "Starting Docker services..."
           }
         ]
+      },
+      {
+        "matcher": "startup|resume|clear",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "command -v jq >/dev/null 2>&1 || { echo '⚠️  jq is not installed on the host — the Edit/Write formatting hooks read the edited file path from the tool payload via jq and will silently no-op until you install it (brew install jq).' >&2; exit 2; }",
+            "timeout": 10,
+            "statusMessage": "Checking host prerequisites..."
+          }
+        ]
       }
     ],
     "PreToolUse": [
       {
-        "matcher": "Edit|Write",
+        "matcher": "Edit|MultiEdit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "case \"$CLAUDE_FILE_PATH\" in */composer.lock|*/yarn.lock|*/.env.local|*/.env.local.*) echo 'BLOCKED: Do not edit lock files or .env.local directly' >&2; exit 1 ;; esac"
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in */composer.lock|*/symfony.lock|*/.env.local|*/.env.*.local|*/config/reference.php|*/vendor/*|*/node_modules/*|*/var/cache/*) echo 'BLOCKED: this path is generated, locked, or operator-only — edit the source instead' >&2; exit 2 ;; esac"
           }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "Write|Edit",
+        "matcher": "Edit|MultiEdit|Write",
         "hooks": [
           {
             "type": "command",
-            "command": "case \"$CLAUDE_FILE_PATH\" in *.php) REL_PATH=\"${CLAUDE_FILE_PATH#$CLAUDE_PROJECT_DIR/}\"; docker compose exec -T phpfpm vendor/bin/php-cs-fixer fix --quiet \"$REL_PATH\" 2>/dev/null || true ;; esac",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.php) REL_PATH=\"${f#\"$CLAUDE_PROJECT_DIR\"/}\"; docker compose exec -T phpfpm vendor/bin/php-cs-fixer fix --quiet \"$REL_PATH\" 2>/dev/null || true ;; esac",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "case \"$CLAUDE_FILE_PATH\" in *.php) REL_PATH=\"${CLAUDE_FILE_PATH#$CLAUDE_PROJECT_DIR/}\"; docker compose exec -T phpfpm vendor/bin/phpstan analyse --no-progress --error-format=raw \"$REL_PATH\" 2>/dev/null || true ;; esac",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.php) REL_PATH=\"${f#\"$CLAUDE_PROJECT_DIR\"/}\"; docker compose exec -T phpfpm vendor/bin/phpstan analyse --no-progress --error-format=raw \"$REL_PATH\" 2>/dev/null || true ;; esac",
+            "timeout": 45
+          },
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.twig) REL_PATH=\"${f#\"$CLAUDE_PROJECT_DIR\"/}\"; docker compose exec -T phpfpm vendor/bin/twig-cs-fixer lint --fix \"$REL_PATH\" 2>/dev/null || true ;; esac",
+            "timeout": 15
+          },
+          {
+            "type": "command",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in */composer.json) docker compose exec -T phpfpm composer normalize --quiet 2>/dev/null || true ;; esac",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "case \"$CLAUDE_FILE_PATH\" in *.twig) REL_PATH=\"${CLAUDE_FILE_PATH#$CLAUDE_PROJECT_DIR/}\"; docker compose exec -T phpfpm vendor/bin/twig-cs-fixer lint --fix \"$REL_PATH\" 2>/dev/null || true ;; esac",
-            "timeout": 15
-          },
-          {
-            "type": "command",
-            "command": "case \"$CLAUDE_FILE_PATH\" in */composer.json) docker compose exec -T phpfpm composer normalize --quiet 2>/dev/null || true ;; esac",
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.yaml|*.yml|*.js|*.css) REL_PATH=\"${f#\"$CLAUDE_PROJECT_DIR\"/}\"; docker compose run --rm -T prettier \"$REL_PATH\" --write 2>/dev/null || true ;; esac",
             "timeout": 30
           },
           {
             "type": "command",
-            "command": "case \"$CLAUDE_FILE_PATH\" in *.yaml|*.yml) REL_PATH=\"${CLAUDE_FILE_PATH#$CLAUDE_PROJECT_DIR/}\"; docker compose run --rm -T prettier \"$REL_PATH\" --write 2>/dev/null || true ;; esac",
-            "timeout": 15
-          },
-          {
-            "type": "command",
-            "command": "case \"$CLAUDE_FILE_PATH\" in *.md) REL_PATH=\"${CLAUDE_FILE_PATH#$CLAUDE_PROJECT_DIR/}\"; docker compose run --rm -T markdownlint markdownlint \"$REL_PATH\" --fix 2>/dev/null || true ;; esac",
-            "timeout": 15
+            "command": "f=$(jq -r '.tool_input.file_path // empty'); case \"$f\" in *.md) REL_PATH=\"${f#\"$CLAUDE_PROJECT_DIR\"/}\"; docker compose run --rm -T markdownlint markdownlint --fix \"$REL_PATH\" 2>/dev/null || true ;; esac",
+            "timeout": 30
           }
         ]
       }
@@ -147,6 +158,12 @@
             "command": "docker compose exec -T phpfpm bin/console lint:container 2>/dev/null || true",
             "timeout": 30,
             "statusMessage": "Validating Symfony DI container..."
+          },
+          {
+            "type": "command",
+            "command": "sh \"$CLAUDE_PROJECT_DIR/scripts/claude-hook-check-index-contract.sh\" || true",
+            "timeout": 10,
+            "statusMessage": "Checking Elasticsearch index contract..."
           }
         ]
       }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-28](https://github.com/itk-dev/event-database-api/pull/28)
+  Adapt Claude Code setup from event-database-imports: fix the Edit/Write hook
+  mechanism (read the file path from the tool payload via jq instead of the
+  unset CLAUDE_FILE_PATH), guard the shared Elasticsearch index contract on
+  Stop, and document the cross-repo relationship in CLAUDE.md
 - [PR-27](https://github.com/itk-dev/event-database-api/pull/27)
   Add Claude Code project setup (CLAUDE.md, agents, skills)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,7 @@ See [keep a changelog] for information about writing changes to this log.
 ## [Unreleased]
 
 - [PR-28](https://github.com/itk-dev/event-database-api/pull/28)
-  Adapt Claude Code setup from event-database-imports: fix the Edit/Write hook
-  mechanism (read the file path from the tool payload via jq instead of the
-  unset CLAUDE_FILE_PATH), guard the shared Elasticsearch index contract on
-  Stop, and document the cross-repo relationship in CLAUDE.md
+  Adapt Claude Code hooks from event-database-imports and guard the ES index contract
 - [PR-27](https://github.com/itk-dev/event-database-api/pull/27)
   Add Claude Code project setup (CLAUDE.md, agents, skills)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,3 +117,42 @@ JSON-encoded `APP_API_KEYS` env var. `/api/v2/docs` is public; everything else u
   will fail the suite.
 - PHPStan errors about `App\Api\Dto\*::$id` being unused are intentionally ignored (API Platform writes the property
   reflectively).
+
+## Works with event-database-imports
+
+This repo is the public **read-only** API; [`event-database-imports`](https://github.com/itk-dev/event-database-imports)
+is the **write/admin** side. They are decoupled at runtime and communicate only through a **shared Elasticsearch
+cluster** — no shared database, no HTTP call between them.
+
+- **The importer writes; this repo reads.** The importer runs feed import → normalize → persist (MariaDB) → index
+  into ES. This repo serves `/api/v2/…` by reading those same ES indices (`INDEX_URL`); it has **no domain
+  database** and must never write to ES.
+- **The importer owns the index lifecycle.** It builds a versioned index `<alias>_<timestamp>`, then atomically
+  repoints the alias. This repo always queries the **alias** — so it never sees a half-built index, but a resource
+  returns empty if the alias was never populated.
+- **The contract is hand-duplicated, with no compile-time link:**
+  - Index names — `src/Model/IndexName.php` here ↔ `src/Model/Indexing/IndexNames.php` in the importer
+    (`events`, `organizations`, `occurrences`, `daily_occurrences`, `tags`, `vocabularies`, `locations`).
+  - Document shape — mappings live **only in the importer** (`src/Model/Indexing/Mappings/`); this repo has none and
+    trusts the fields/types the importer writes. A renamed or retyped field silently breaks the filters/providers
+    here (they reference ES field names directly).
+  - Keep both in sync when changing either. The `Stop` hook (below) warns when `src/Model/IndexName.php` changes.
+- **Co-hosted by path prefix** in production: `/api/v2/` → this app, `/admin/` → the importer, via Traefik on the
+  shared `frontend` network.
+
+## Claude Code automation
+
+`.claude/settings.json`, `.claude/agents/`, and `.claude/skills/` configure this repo's Claude Code setup. All hooks
+run tooling **inside the `phpfpm` container**.
+
+- **Hooks** — `SessionStart` boots the Docker stack and checks host prerequisites; `PostToolUse` auto-runs
+  php-cs-fixer, phpstan, twig-cs-fixer, `composer normalize`, prettier, and markdownlint on the file you just edited
+  (so single-file changes don't need manual formatting); `PreToolUse` blocks edits to generated/locked/secret files
+  (`config/reference.php`, lock files, `.env.local`, …); `Stop` validates the DI container (`lint:container`) and
+  warns on ES index-contract changes (`scripts/claude-hook-check-index-contract.sh`).
+- **Prerequisite:** `jq` must be installed on the **host** — the Edit/Write hooks read the edited file path from the
+  tool payload via `jq` and silently no-op without it (`brew install jq`; a `SessionStart` hook warns if missing).
+- **Subagents** (`.claude/agents/`): `pr-readiness` (run all CI-equivalent checks) and `reload-fixtures` (reload ES
+  fixtures / recover a not-ready cluster).
+- **Skills** (`.claude/skills/`, user-invocable): `/update-api-spec` (regenerate `public/spec.yaml` after changing
+  an API resource).

--- a/scripts/claude-hook-check-index-contract.sh
+++ b/scripts/claude-hook-check-index-contract.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Stop-hook helper: warn when the Elasticsearch index contract changed.
+#
+# event-database-imports WRITES the ES indices; this repo (event-database-api)
+# READS them. The contract (index-name enum + document field names/types) is
+# duplicated by hand across both repos with no compile-time link. This repo owns
+# only the index-name enum; the document mappings live solely in the importer.
+# See CLAUDE.md -> "Works with event-database-imports".
+set -u
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+CHANGED="$(git status --porcelain 2>/dev/null | awk '{print $NF}')"
+
+echo "$CHANGED" | grep -qE '^src/Model/IndexName\.php' || exit 0
+
+cat >&2 <<'MSG'
+WARN: the Elasticsearch index-name enum changed (src/Model/IndexName.php).
+      event-database-imports writes these indices and duplicates the contract by
+      hand in its src/Model/Indexing/IndexNames.php. An index name that does not
+      match what the importer creates (and populates behind the queried alias)
+      yields an empty or failing API resource. Coordinate the change with
+      event-database-imports before deploying.
+MSG
+
+exit 0


### PR DESCRIPTION
Adapt the Claude Code tooling from the sibling [`event-database-imports` PR #81](https://github.com/itk-dev/event-database-imports/pull/81) to this repo, scoped to the parts that apply to a read-only API.

## Changes

- **`.claude/settings.json`**
  - Fix the `Edit`/`Write` hooks: read the edited file path from the tool payload via `jq` (`.tool_input.file_path`) instead of `$CLAUDE_FILE_PATH`. Claude Code never sets that env var, so the previous formatting/blocking hooks **silently no-oped**.
  - `SessionStart`: warn when `jq` is missing on the host (the hooks now depend on it).
  - `PreToolUse`: widen the blocklist (`symfony.lock`, `config/reference.php`, `vendor/`, `node_modules/`, `var/cache/`), add the `MultiEdit` matcher, and use `exit 2` so a blocked edit is actually rejected.
  - `Stop`: run `scripts/claude-hook-check-index-contract.sh` in addition to `lint:container`.
- **`scripts/claude-hook-check-index-contract.sh`** — Stop-hook helper (mirror of the importer's, from the *consumer* side) that warns when `src/Model/IndexName.php` changes, since the importer duplicates the index-name contract by hand.
- **`CLAUDE.md`** — add a "Works with event-database-imports" section (shared Elasticsearch contract, index lifecycle, hand-duplicated names/mappings) and a "Claude Code automation" reference.
- **`CHANGELOG.md`** — `[Unreleased]` entry.

## Why

The repo's Claude hooks were carried over from an earlier setup that keyed on `$CLAUDE_FILE_PATH`; that variable isn't populated by Claude Code, so single-file auto-formatting and the lock-file guard never actually ran. The importer PR verified the `jq`-from-stdin mechanism, so this brings the same working approach here. The index-contract guard matters more on this side: the API has no mapping definitions of its own and trusts the fields/types the importer writes, so a contract change elsewhere can silently break filters/providers here.

## Out of scope (deliberately not adapted)

- **Symfony AI Mate MCP** — needs composer dev deps + generated files (`mate/`, `AGENTS.md`, `bin/codex`); low value for a read-only API with no service graph to introspect. Easy to add later if wanted.
- **`create-migration` / `messenger-handler-reviewer` / `authorization-reviewer` subagents** — no Doctrine migrations, no Messenger pipeline, and only trivial API-key auth here.