### PR TITLE
chore: add Claude Code automations (skills, subagent, spec-drift hook)

### DIFF
--- a/.claude/agents/filter-provider-reviewer.md
+++ b/.claude/agents/filter-provider-reviewer.md
@@ -1,0 +1,34 @@
+---
+name: filter-provider-reviewer
+description: Review changes to Elasticsearch filters and state providers for query-DSL correctness and index-contract alignment. Use after editing anything under src/Api/Filter/ElasticSearch/ or src/Api/State/.
+---
+
+You review the riskiest code in this repo: the custom Elasticsearch filters (`src/Api/Filter/ElasticSearch/`) and
+the state providers (`src/Api/State/`) that assemble them. Unlike stock API Platform filters, these emit **raw
+Elasticsearch query DSL** rather than mutating a Doctrine query builder, and the document mappings they target are
+owned by `event-database-imports` — so a generic code reviewer misses the failure modes that matter here.
+
+Focus your review on:
+
+1. **Query-DSL correctness.** `apply()` returns ES query fragments, not query-builder mutations. Check the emitted
+   DSL is well-formed for its intent (`term`/`terms` vs `match`, `range` bounds, `bool` `must`/`should`/`filter`
+   nesting) and that clauses compose rather than overwrite when multiple filters apply to one request.
+
+2. **Filter vs sort separation.** `AbstractProvider::getFilters()` splits filter clauses from sort clauses via the
+   `SortFilterInterface` marker. A new sorting filter must implement that marker or it will be treated as a query
+   clause; a query filter must not.
+
+3. **Index-contract alignment.** Field names/types referenced in the DSL must match what `event-database-imports`
+   writes (mappings live only there — this repo has none). A typo'd or renamed field yields empty/incorrect results
+   silently, not an error. Flag any field reference you can't confirm against the index contract and recommend
+   verifying against a live mapping (`docker compose exec -T phpfpm curl -s http://elasticsearch:9200/<index>/_mapping`).
+
+4. **Pagination & limits.** `paginationMaximumItemsPerPage` on the DTO and `AbstractProvider::MAX_PAGE_SIZE_FALLBACK`
+   (20) bound page size — check a new provider respects them and returns `SearchResults` for collections / a single
+   array for items.
+
+5. **Filter registration.** Filters are attached via `#[ApiFilter(...)]` on the DTO and picked up through
+   `api_platform.filter_locator`. Confirm a new filter is actually reachable that way, not just defined.
+
+Report concrete, file:line findings ranked by severity. Prefer verifying a claim against the code or a live ES
+query over speculating. Do not restate what is correct at length — surface what is wrong or unverifiable.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -164,6 +164,12 @@
             "command": "sh \"$CLAUDE_PROJECT_DIR/scripts/claude-hook-check-index-contract.sh\" || true",
             "timeout": 10,
             "statusMessage": "Checking Elasticsearch index contract..."
+          },
+          {
+            "type": "command",
+            "command": "sh \"$CLAUDE_PROJECT_DIR/scripts/claude-hook-check-spec-drift.sh\" || true",
+            "timeout": 10,
+            "statusMessage": "Checking OpenAPI spec is up to date..."
           }
         ]
       }

--- a/.claude/skills/changelog-entry/SKILL.md
+++ b/.claude/skills/changelog-entry/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: changelog-entry
+description: Add or fix this repo's CHANGELOG.md entry for the current PR, in the exact house format. Use before opening a PR or when resolving a CHANGELOG merge conflict.
+disable-model-invocation: true
+---
+
+Add a changelog line for the current work to `CHANGELOG.md`, following this repo's convention exactly (getting it wrong causes the `changelog` CI check in `.github/workflows/changelog.yaml` to fail and creates repeated merge conflicts).
+
+## Format
+
+Under the `## [Unreleased]` heading, entries are a **two-line wrapped** list item:
+
+```
+- [PR-N](https://github.com/itk-dev/event-database-api/pull/N)
+  Short imperative description of the change
+```
+
+Rules:
+
+- One entry per PR. Ordered by **descending PR number** (newest on top).
+- The URL is always the `event-database-api` repo (not `event-database-imports`).
+- **Keep it short and terse — match the surrounding entries.** The description is a single concise noun or
+  imperative phrase naming *what* changed, not a sentence (or paragraph) explaining *how*. It fits on one wrapped
+  line and almost always well under the 120-char limit (markdownlint MD013). If you're tempted to list mechanisms,
+  reasons, or multiple clauses, cut them — that detail belongs in the PR description, not the changelog.
+  - Good (real entries): `Symfony 7.3 and PHP 8.4` · `Re-lint YAML files` ·
+    `Add Claude Code project setup (CLAUDE.md, agents, skills)`
+  - Too long: `Adapt Claude Code setup from event-database-imports: fix the Edit/Write hook mechanism (read the
+    file path from the tool payload via jq instead of the unset CLAUDE_FILE_PATH), guard the …`
+- Some historical entries are plain bullets without a PR link (e.g. dependency bumps) — that's fine for changes
+  without a PR, but PR-based work always gets the `[PR-N]` form.
+
+## Two-step PR number
+
+The PR number isn't known until the PR exists. So:
+
+1. Add the entry now with a `PR-XX` placeholder and `pull/XX` URL.
+2. After the PR is opened (`gh pr view --json number`), replace `XX` with the real number in a follow-up commit (`docs: set PR number in CHANGELOG entry`).
+
+## Steps
+
+1. `git fetch origin develop` and read the current `[Unreleased]` block so you insert in the right order and don't duplicate.
+2. Insert the entry at the correct descending-number position.
+3. Lint: `docker compose run --rm markdownlint markdownlint CHANGELOG.md`.
+4. If a PR already exists, set the real number; otherwise leave `XX` and remind the user of step 2.

--- a/.claude/skills/new-resource/SKILL.md
+++ b/.claude/skills/new-resource/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: new-resource
+description: Scaffold a new read-only API resource backed by an Elasticsearch index, following this repo's DTO + provider + filter pattern. Use when exposing a new index (or a new shape of an existing one) under /api/v2.
+disable-model-invocation: true
+---
+
+Add a new API Platform resource. This repo's resources are **DTOs backed by Elasticsearch**, never Doctrine
+entities — every resource follows the same three-part shape, with `Event` as the canonical template. Read
+`src/Api/Dto/Event.php`, `src/Api/State/EventRepresentationProvider.php`, and `tests/ApiPlatform/EventsTest.php`
+before starting, and mirror them.
+
+## Steps
+
+1. **Confirm the index.** The seven indices live in `src/Model/IndexName.php`. If the resource maps to an existing
+   index, reuse that enum case. If it's a genuinely new index, add a case — and remember the mapping is owned by
+   `event-database-imports` (see CLAUDE.md → "Works with event-database-imports"); coordinate the contract there.
+
+2. **DTO** — `src/Api/Dto/<Resource>.php`: an `#[ApiResource]` class declaring operations, pagination
+   (`paginationMaximumItemsPerPage`), and `#[ApiFilter(...)]` attributes. The `$id` property is identifier-only
+   (PHPStan "unused" errors on it are intentionally ignored); real fields are filled by the provider. Attach
+   filters from `src/Api/Filter/ElasticSearch/` (`MatchFilter`, `IdFilter`, `BooleanFilter`, `DateRangeFilter`,
+   `DateFilter`, `TagFilter`) — do not invent a Doctrine filter.
+
+3. **Provider** — `src/Api/State/<Resource>RepresentationProvider.php`: implement `ProviderInterface` by extending
+   `AbstractProvider`. Use `getFilters()` to compile the declared `#[ApiFilter]` attributes into ES query
+   fragments, call `IndexInterface::search()`, and return a `SearchResults` (collection op) or a single array
+   (item op). Wire the DTO's `provider:` to this class. Providers are autoconfigured — only touch
+   `config/services.yaml` if you need explicit arguments.
+
+4. **Test** — `tests/ApiPlatform/<Resource>Test.php`: extend `AbstractApiTestCase`, `use` `GetEntitiesTestTrait`
+   and `GetItemTestTrait`, and set the static props (`$requestPath`, `$resourceClass`, `$itemId`,
+   `$unknownItemId`). Add resource-specific filter assertions in a `<Resource>FilterTest.php`. Add fixture rows to
+   `tests/resources/<index>.json` so `$itemId` resolves (see `tests/resources/README.md`).
+
+5. **Regenerate the OpenAPI spec** — run the `/update-api-spec` skill (or `task api:spec:export`). CI
+   (`.github/workflows/api-spec.yml`) fails if `public/spec.yaml` is stale.
+
+6. **Verify** — `task fixtures:load:test --yes` then `task api:test -- --filter <Resource>`. Run
+   `task coding-standards:check` and `task code-analysis` before opening the PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,10 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-29](https://github.com/itk-dev/event-database-api/pull/29)
+  Add Claude Code skills, filter/provider reviewer subagent, and spec-drift hook
 - [PR-28](https://github.com/itk-dev/event-database-api/pull/28)
-  Adapt Claude Code setup from event-database-imports: fix the Edit/Write hook
-  mechanism (read the file path from the tool payload via jq instead of the
-  unset CLAUDE_FILE_PATH), guard the shared Elasticsearch index contract on
-  Stop, and document the cross-repo relationship in CLAUDE.md
+  Adapt Claude Code hooks from event-database-imports and guard the ES index contract
 - [PR-27](https://github.com/itk-dev/event-database-api/pull/27)
   Add Claude Code project setup (CLAUDE.md, agents, skills)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,11 +148,14 @@ run tooling **inside the `phpfpm` container**.
 - **Hooks** — `SessionStart` boots the Docker stack and checks host prerequisites; `PostToolUse` auto-runs
   php-cs-fixer, phpstan, twig-cs-fixer, `composer normalize`, prettier, and markdownlint on the file you just edited
   (so single-file changes don't need manual formatting); `PreToolUse` blocks edits to generated/locked/secret files
-  (`config/reference.php`, lock files, `.env.local`, …); `Stop` validates the DI container (`lint:container`) and
-  warns on ES index-contract changes (`scripts/claude-hook-check-index-contract.sh`).
+  (`config/reference.php`, lock files, `.env.local`, …); `Stop` validates the DI container (`lint:container`), warns
+  on ES index-contract changes (`scripts/claude-hook-check-index-contract.sh`), and warns when a resource changed
+  but `public/spec.yaml` was not regenerated (`scripts/claude-hook-check-spec-drift.sh`).
 - **Prerequisite:** `jq` must be installed on the **host** — the Edit/Write hooks read the edited file path from the
   tool payload via `jq` and silently no-op without it (`brew install jq`; a `SessionStart` hook warns if missing).
-- **Subagents** (`.claude/agents/`): `pr-readiness` (run all CI-equivalent checks) and `reload-fixtures` (reload ES
-  fixtures / recover a not-ready cluster).
+- **Subagents** (`.claude/agents/`): `pr-readiness` (run all CI-equivalent checks), `reload-fixtures` (reload ES
+  fixtures / recover a not-ready cluster), and `filter-provider-reviewer` (review ES filter/provider changes for
+  query-DSL correctness and index-contract alignment).
 - **Skills** (`.claude/skills/`, user-invocable): `/update-api-spec` (regenerate `public/spec.yaml` after changing
-  an API resource).
+  an API resource), `/changelog-entry` (add the CHANGELOG entry in the CI-enforced format), and `/new-resource`
+  (scaffold a new index-backed resource following the DTO + provider + filter pattern).

--- a/scripts/claude-hook-check-spec-drift.sh
+++ b/scripts/claude-hook-check-spec-drift.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# Stop-hook helper: warn when an API resource changed but public/spec.yaml did not.
+#
+# public/spec.yaml is the committed OpenAPI export and is checked in CI
+# (.github/workflows/api-spec.yml). Editing an #[ApiResource] DTO without
+# regenerating the spec fails that check. This warns locally, before CI does.
+# See CLAUDE.md -> "Claude Code automation".
+set -u
+
+cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
+
+CHANGED="$(git status --porcelain 2>/dev/null | awk '{print $NF}')"
+
+# A DTO changed?
+echo "$CHANGED" | grep -qE '^src/Api/Dto/.*\.php$' || exit 0
+# ...but the spec did not.
+echo "$CHANGED" | grep -qE '^public/spec\.yaml$' && exit 0
+
+cat >&2 <<'MSG'
+WARN: an API resource under src/Api/Dto/ changed but public/spec.yaml was not
+      regenerated. CI (.github/workflows/api-spec.yml) checks the committed
+      OpenAPI export and will fail on a stale spec. Regenerate it with:
+        task api:spec:export      (or the /update-api-spec skill)
+MSG
+
+exit 0


### PR DESCRIPTION
Add the zero-dependency automations from the automation review. Stacked on #28 (shares the `settings.json` Stop block) — review/merge #28 first, then this retargets to `develop`.

## Changes

- **`.claude/skills/changelog-entry/`** (user-invocable) — add the CHANGELOG `[Unreleased]` entry in the CI-enforced format (`.github/workflows/changelog.yaml`), with explicit guidance to match the terse house tone.
- **`.claude/skills/new-resource/`** (user-invocable) — scaffold a new ES-index-backed resource following the DTO + provider + filter pattern, using `Event` as the template.
- **`.claude/agents/filter-provider-reviewer.md`** — subagent that reviews `src/Api/Filter/ElasticSearch/` and `src/Api/State/` changes for query-DSL correctness, filter-vs-sort separation, and index-contract alignment.
- **`scripts/claude-hook-check-spec-drift.sh`** + `Stop` hook — warn when an `src/Api/Dto/*` resource changed but `public/spec.yaml` was not regenerated (which CI's `api-spec.yml` would fail on).
- **`CLAUDE.md`** — list the new skills/subagent/hook in the automation section.

## Why

These four items came out of the automation-recommender review and, unlike the Elasticsearch MCP it also suggested, need no external runtime — they're pure repo files. They target this repo's real friction points: the CI-enforced changelog format, the rigid resource-scaffolding pattern, the raw-ES-DSL filter code, and spec drift.

## Deliberately excluded

- **Elasticsearch MCP** — the only recommended item needing an external runtime. The sibling `event-database-imports` repo did not adopt one, and ad-hoc ES access via `docker compose exec phpfpm curl http://elasticsearch:9200/...` covers the need with no new dependency. Can be added later as a one-line `docker run` MCP entry if wanted.

## Note

- The `.claude/skills/*` and `.claude/agents/*` markdown isn't covered by CI's `markdownlint '**/*.md'` (hidden-dir glob), matching the existing `update-api-spec` skill.