### PR TITLE
test: mature the API test suite ahead of the API Platform upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-33](https://github.com/itk-dev/event-database-api/pull/33)
+  Mature the API test suite ahead of the API Platform upgrade (contract, filter, pagination and error tests)
 - [PR-31](https://github.com/itk-dev/event-database-api/pull/31)
   Align dev tooling with event-database-imports: PHPStan level 8 + strict rules, PHP 8.4, twig-cs-fixer v4, PHPUnit 13
 - [PR-30](https://github.com/itk-dev/event-database-api/pull/30)

--- a/tests/ApiPlatform/AbstractApiTestCase.php
+++ b/tests/ApiPlatform/AbstractApiTestCase.php
@@ -12,6 +12,12 @@ abstract class AbstractApiTestCase extends ApiTestCase
 
     protected static string $requestPath;
 
+    protected static string $resourceClass;
+
+    protected static int|string $itemId;
+
+    protected static int|string $unknownItemId = 99999;
+
     protected static function createAuthenticatedClient(): Client
     {
         return static::createClient(defaultOptions: [

--- a/tests/ApiPlatform/AuthenticationTest.php
+++ b/tests/ApiPlatform/AuthenticationTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verify the API key auth boundary across all resources.
+ */
+class AuthenticationTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/events';
+
+    #[DataProvider('protectedEndpointProvider')]
+    public function testMissingApiKeyReturns401(string $path): void
+    {
+        self::createClient()
+            ->request('GET', $path, ['headers' => ['accept' => 'application/ld+json']]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[DataProvider('protectedEndpointProvider')]
+    public function testInvalidApiKeyReturns401(string $path): void
+    {
+        self::createClient()
+            ->request('GET', $path, [
+                'headers' => [
+                    'accept' => 'application/ld+json',
+                    'x-api-key' => 'wrong_key',
+                ],
+            ]);
+
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+    }
+
+    #[DataProvider('protectedEndpointProvider')]
+    public function testValidApiKeyReturns200(string $path): void
+    {
+        $this->get([], $path);
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+    }
+
+    public function testDocsEndpointIsPublic(): void
+    {
+        self::createClient()->request('GET', '/api/v2/docs');
+        $this->assertResponseIsSuccessful();
+    }
+
+    public static function protectedEndpointProvider(): iterable
+    {
+        yield 'events' => ['/api/v2/events'];
+        yield 'occurrences' => ['/api/v2/occurrences'];
+        yield 'daily_occurrences' => ['/api/v2/daily_occurrences'];
+        yield 'locations' => ['/api/v2/locations'];
+        yield 'organizations' => ['/api/v2/organizations'];
+        yield 'tags' => ['/api/v2/tags'];
+        yield 'vocabularies' => ['/api/v2/vocabularies'];
+    }
+}

--- a/tests/ApiPlatform/Contract/CollectionContractTest.php
+++ b/tests/ApiPlatform/Contract/CollectionContractTest.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Tests\ApiPlatform\Contract;
+
+use App\Tests\ApiPlatform\AbstractApiTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Locks the JSON-LD / Hydra collection envelope and the exact member field set
+ * of every resource, so an API Platform upgrade cannot silently change the
+ * response contract (renamed/dropped fields, changed @var, altered hydra:*
+ * envelope). These assertions are deliberately independent of API Platform's
+ * self-generated JSON schema (which regenerates with the upgrade).
+ *
+ * Captured against the current version; treat any diff during the upgrade as a
+ * potential BC break to reconcile against the "no BC changes" rule.
+ */
+class CollectionContractTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/events';
+
+    #[DataProvider('collectionProvider')]
+    public function testCollectionEnvelope(string $path, string $context, array $expectedKeys): void
+    {
+        unset($expectedKeys);
+        $data = $this->get([], $path)->toArray();
+
+        $this->assertSame('/api/v2/contexts/'.$context, $data['@context'], $path.' @context');
+        $this->assertSame($path, $data['@id'], $path.' @id');
+        $this->assertSame('hydra:Collection', $data['@type'], $path.' @type');
+        $this->assertIsInt($data['hydra:totalItems'], $path.' hydra:totalItems must be an int');
+        $this->assertIsList($data['hydra:member'], $path.' hydra:member must be a JSON list');
+    }
+
+    #[DataProvider('collectionProvider')]
+    public function testCollectionMemberFieldSet(string $path, string $context, array $expectedKeys): void
+    {
+        unset($context);
+        $data = $this->get([], $path)->toArray();
+        $this->assertNotEmpty($data['hydra:member'], $path.' needs at least one fixture member');
+
+        $this->assertEqualsCanonicalizing(
+            $expectedKeys,
+            array_keys($data['hydra:member'][0]),
+            $path.' member field set changed — potential BC break'
+        );
+    }
+
+    #[DataProvider('collectionProvider')]
+    public function testCollectionExposesHydraSearch(string $path, string $context, array $expectedKeys): void
+    {
+        unset($context, $expectedKeys);
+        $data = $this->get([], $path)->toArray();
+
+        $this->assertArrayHasKey('hydra:search', $data, $path.' must expose hydra:search');
+        $this->assertSame('hydra:IriTemplate', $data['hydra:search']['@type']);
+        $this->assertIsString($data['hydra:search']['hydra:template']);
+        $this->assertIsList($data['hydra:search']['hydra:mapping']);
+        $this->assertSame('IriTemplateMapping', $data['hydra:search']['hydra:mapping'][0]['@type']);
+    }
+
+    public static function collectionProvider(): iterable
+    {
+        // Nested resources (Event/Occurrence/DailyOccurrence/Location/Organization)
+        // are serialized as plain objects — NOTE their members carry NO @id/@type.
+        yield 'events' => ['/api/v2/events', 'Event', [
+            'entityId', 'title', 'excerpt', 'description', 'url', 'ticketUrl', 'publicAccess',
+            'organizer', 'partners', 'occurrences', 'dailyOccurrences', 'tags', 'imageUrls',
+            'created', 'updated', 'location',
+        ]];
+        yield 'occurrences' => ['/api/v2/occurrences', 'Occurrence', [
+            'entityId', 'start', 'end', 'ticketPriceRange', 'room', 'event', 'status',
+        ]];
+        yield 'daily_occurrences' => ['/api/v2/daily_occurrences', 'DailyOccurrence', [
+            'entityId', 'start', 'end', 'ticketPriceRange', 'room', 'status', 'event',
+        ]];
+        yield 'locations' => ['/api/v2/locations', 'Location', [
+            'entityId', 'name', 'image', 'url', 'telephone', 'disabilityAccess', 'mail',
+            'street', 'suite', 'region', 'city', 'country', 'postalCode', 'coordinates',
+        ]];
+        yield 'organizations' => ['/api/v2/organizations', 'Organization', [
+            'entityId', 'name', 'email', 'url', 'created', 'updated',
+        ]];
+        // Tag/Vocabulary ARE true API Platform resources — their members DO carry @id/@type.
+        yield 'tags' => ['/api/v2/tags', 'Tag', [
+            '@id', '@type', 'slug', 'name',
+        ]];
+        yield 'vocabularies' => ['/api/v2/vocabularies', 'Vocabulary', [
+            '@id', '@type', 'slug', 'name', 'description', 'tags',
+        ]];
+    }
+}

--- a/tests/ApiPlatform/Contract/ContentNegotiationContractTest.php
+++ b/tests/ApiPlatform/Contract/ContentNegotiationContractTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Tests\ApiPlatform\Contract;
+
+use App\Tests\ApiPlatform\AbstractApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Locks content negotiation. The API currently serves ONLY application/ld+json:
+ * requesting application/json or text/html yields 406 Not Acceptable. This is a
+ * strong client-facing contract and a likely BC-sensitive area on upgrade
+ * (default formats, negotiation behaviour).
+ */
+class ContentNegotiationContractTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/events';
+
+    public function testLdJsonIsSupported(): void
+    {
+        $response = $this->requestWithAccept('application/ld+json');
+
+        $this->assertSame(Response::HTTP_OK, $response->getStatusCode());
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+    }
+
+    public function testPlainJsonIsNotAcceptable(): void
+    {
+        $response = $this->requestWithAccept('application/json');
+
+        $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $response->getStatusCode(), 'The API currently rejects application/json');
+    }
+
+    public function testHtmlIsNotAcceptable(): void
+    {
+        $response = $this->requestWithAccept('text/html');
+
+        $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $response->getStatusCode(), 'The API currently rejects text/html on resource endpoints');
+    }
+
+    private function requestWithAccept(string $accept): ResponseInterface
+    {
+        $client = self::createClient(defaultOptions: [
+            'headers' => [
+                'accept' => [$accept],
+                'x-api-key' => 'test_api_key',
+            ],
+        ]);
+
+        return $client->request('GET', '/api/v2/events');
+    }
+}

--- a/tests/ApiPlatform/Contract/DateFormatContractTest.php
+++ b/tests/ApiPlatform/Contract/DateFormatContractTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Tests\ApiPlatform\Contract;
+
+use App\Tests\ApiPlatform\AbstractApiTestCase;
+
+/**
+ * Locks the datetime serialization format: ISO 8601 with an explicit timezone
+ * offset (e.g. "2024-12-08T12:30:00+01:00"), rendered in the local timezone
+ * (not UTC "Z"). Date serialization is a common BC-sensitive area on upgrade.
+ */
+class DateFormatContractTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/events';
+
+    private const ISO_8601_OFFSET = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/';
+
+    public function testOccurrenceDatesUseIso8601WithOffset(): void
+    {
+        $data = $this->get([], '/api/v2/occurrences')->toArray();
+        $member = $data['hydra:member'][0];
+
+        $this->assertMatchesRegularExpression(self::ISO_8601_OFFSET, $member['start'], 'occurrence.start');
+        $this->assertMatchesRegularExpression(self::ISO_8601_OFFSET, $member['end'], 'occurrence.end');
+    }
+
+    public function testAuditDatesUseIso8601WithOffset(): void
+    {
+        $data = $this->get([], '/api/v2/organizations')->toArray();
+        $member = $data['hydra:member'][0];
+
+        $this->assertMatchesRegularExpression(self::ISO_8601_OFFSET, $member['created'], 'organization.created');
+        $this->assertMatchesRegularExpression(self::ISO_8601_OFFSET, $member['updated'], 'organization.updated');
+    }
+}

--- a/tests/ApiPlatform/Contract/ErrorContractTest.php
+++ b/tests/ApiPlatform/Contract/ErrorContractTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Tests\ApiPlatform\Contract;
+
+use App\Tests\ApiPlatform\AbstractApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Locks the error-response contract. API Platform has changed error
+ * serialization across versions (hydra:Error vs problem+json, field names), so
+ * the exact shape of 401/404 is worth pinning before the upgrade.
+ *
+ * Note: the body also carries a `trace` array in the test env (debug on); that
+ * is environment-dependent and intentionally NOT asserted here.
+ */
+class ErrorContractTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/events';
+
+    public function testUnauthenticatedErrorShape(): void
+    {
+        $client = self::createClient();
+        $response = $client->request('GET', '/api/v2/events');
+
+        $this->assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        $data = $response->toArray(false);
+
+        $this->assertSame('/api/v2/contexts/Error', $data['@context']);
+        $this->assertSame('hydra:Error', $data['@type']);
+        $this->assertSame(401, $data['status']);
+        $this->assertSame('/errors/401', $data['type']);
+        $this->assertArrayHasKey('title', $data);
+        $this->assertArrayHasKey('detail', $data);
+    }
+
+    public function testNotFoundErrorShape(): void
+    {
+        $response = $this->get([], '/api/v2/events/99999');
+
+        $this->assertSame(Response::HTTP_NOT_FOUND, $response->getStatusCode());
+        $data = $response->toArray(false);
+
+        $this->assertSame('/api/v2/contexts/Error', $data['@context']);
+        $this->assertSame('hydra:Error', $data['@type']);
+        $this->assertSame(404, $data['status']);
+        $this->assertSame('/errors/404', $data['type']);
+    }
+}

--- a/tests/ApiPlatform/Contract/ItemContractTest.php
+++ b/tests/ApiPlatform/Contract/ItemContractTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Tests\ApiPlatform\Contract;
+
+use App\Tests\ApiPlatform\AbstractApiTestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Locks the item ("GET one") response shape, which is deliberately inconsistent
+ * in the current API and therefore a high BC-break risk on upgrade:
+ *
+ *  - Event / Occurrence / DailyOccurrence / Location / Organization item
+ *    endpoints return a hydra:Collection wrapper of exactly ONE member (NOT a
+ *    single JSON-LD item), and the member has no @id/@var.
+ *  - Tag / Vocabulary item endpoints return a flat single item with @id/@var.
+ *
+ * See PR notes: this asymmetry is current behaviour, not necessarily desired —
+ * the tests exist to catch it changing during the upgrade.
+ */
+class ItemContractTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/events';
+
+    #[DataProvider('collectionWrappedItemProvider')]
+    public function testCollectionWrappedItem(string $path, int $entityId): void
+    {
+        $data = $this->get([], $path)->toArray();
+
+        $this->assertSame($path, $data['@id'], $path.' @id');
+        $this->assertSame('hydra:Collection', $data['@type'], $path.' item is currently wrapped in a hydra:Collection');
+        $this->assertSame(1, $data['hydra:totalItems'], $path.' should wrap exactly one item');
+        $this->assertCount(1, $data['hydra:member']);
+        $this->assertSame($entityId, $data['hydra:member'][0]['entityId']);
+        $this->assertArrayNotHasKey('@id', $data['hydra:member'][0], 'Wrapped member currently has no @id');
+        $this->assertArrayNotHasKey('@type', $data['hydra:member'][0], 'Wrapped member currently has no @type');
+    }
+
+    #[DataProvider('flatItemProvider')]
+    public function testFlatItem(string $path, string $type, string $slug): void
+    {
+        $data = $this->get([], $path)->toArray();
+
+        $this->assertSame('/api/v2/contexts/'.$type, $data['@context']);
+        $this->assertSame($path, $data['@id'], $path.' @id');
+        $this->assertSame($type, $data['@type'], $path.' flat item @type');
+        $this->assertSame($slug, $data['slug']);
+        $this->assertArrayNotHasKey('hydra:member', $data, $path.' is a flat item, not a collection');
+    }
+
+    public static function collectionWrappedItemProvider(): iterable
+    {
+        yield 'events' => ['/api/v2/events/7', 7];
+        yield 'occurrences' => ['/api/v2/occurrences/10', 10];
+        yield 'daily_occurrences' => ['/api/v2/daily_occurrences/10', 10];
+        yield 'locations' => ['/api/v2/locations/4', 4];
+        yield 'organizations' => ['/api/v2/organizations/9', 9];
+    }
+
+    public static function flatItemProvider(): iterable
+    {
+        yield 'tags' => ['/api/v2/tags/aros', 'Tag', 'aros'];
+        yield 'vocabularies' => ['/api/v2/vocabularies/aarhusguiden', 'Vocabulary', 'aarhusguiden'];
+    }
+}

--- a/tests/ApiPlatform/DailyOccurrencesFilterTest.php
+++ b/tests/ApiPlatform/DailyOccurrencesFilterTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test that filtering daily_occurrences work as expected.
+ */
+class DailyOccurrencesFilterTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/daily_occurrences';
+
+    #[DataProvider('getDailyOccurrencesProvider')]
+    public function testGetDailyOccurrences(array $query, int $expectedCount, ?string $message = null): void
+    {
+        $message ??= '';
+
+        $response = $this->get($query);
+
+        $data = $response->toArray();
+        $this->assertArrayHasKey('hydra:member', $data, $message);
+        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+    }
+
+    public static function getDailyOccurrencesProvider(): iterable
+    {
+        // Unfiltered.
+        yield [[], 3];
+
+        // BooleanFilter on event.publicAccess (DailyOccurrence-specific).
+        yield [
+            ['event.publicAccess' => 'true'],
+            3,
+            'All fixture events have publicAccess=true',
+        ];
+
+        // DateRangeFilter on start.
+        yield [
+            ['start[between]' => static::formatDateTime('2024-12-01').'..'.static::formatDateTime('2024-12-31')],
+            2,
+        ];
+
+        // MatchFilter on event.title (token-based — see OccurrencesFilterTest comment).
+        yield [
+            ['event.title' => 'ITKDev'],
+            3,
+        ];
+
+        // IdFilter on event.organizer.entityId.
+        yield [
+            ['event.organizer.entityId' => 9],
+            3,
+        ];
+
+        // TagFilter on event.tags.
+        yield [
+            ['event.tags' => 'itkdev'],
+            1,
+        ];
+
+        yield [
+            ['event.tags' => 'unknown-tag'],
+            0,
+        ];
+    }
+}

--- a/tests/ApiPlatform/DailyOccurrencesTest.php
+++ b/tests/ApiPlatform/DailyOccurrencesTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use App\Api\Dto\DailyOccurrence;
+use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
+use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
+
+class DailyOccurrencesTest extends AbstractApiTestCase
+{
+    use GetEntitiesTestTrait;
+    use GetItemTestTrait;
+
+    protected static string $requestPath = '/api/v2/daily_occurrences';
+
+    protected static string $resourceClass = DailyOccurrence::class;
+
+    protected static int|string $itemId = 10;
+}

--- a/tests/ApiPlatform/EventsFilterTest.php
+++ b/tests/ApiPlatform/EventsFilterTest.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace ApiPlatform;
+namespace App\Tests\ApiPlatform;
 
-use App\Tests\ApiPlatform\AbstractApiTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
@@ -42,21 +41,9 @@ class EventsFilterTest extends AbstractApiTestCase
             1,
         ];
 
-        // Test DateRangeFilter.
+        // Test DateRangeFilter on occurrences.start.
         yield [
-            ['occurrences.start[between]' => implode('..', [
-                (new \DateTimeImmutable('2001-01-01'))->format(\DateTimeImmutable::ATOM),
-                (new \DateTimeImmutable('2100-01-01'))->format(\DateTimeImmutable::ATOM),
-            ])],
-            3,
-            'Events in 21st century',
-        ];
-
-        yield [
-            ['occurrences.start[between]' => implode('..', [
-                (new \DateTimeImmutable('2001-01-01'))->format(\DateTimeImmutable::ATOM),
-                (new \DateTimeImmutable('2100-01-01'))->format(\DateTimeImmutable::ATOM),
-            ])],
+            ['occurrences.start[between]' => static::formatDateTime('2001-01-01').'..'.static::formatDateTime('2100-01-01')],
             3,
             'Events in 21st century',
         ];
@@ -65,6 +52,19 @@ class EventsFilterTest extends AbstractApiTestCase
             ['occurrences.start[between]' => static::formatDateTime('2026-01-01').'..'.static::formatDateTime('2026-12-31')],
             1,
             'Events in 2026',
+        ];
+
+        // Test DateRangeFilter on updated (default operator: gte).
+        yield [
+            ['updated' => static::formatDateTime('2024-01-01')],
+            3,
+            'Events updated on or after 2024-01-01',
+        ];
+
+        yield [
+            ['updated[gte]' => static::formatDateTime('2100-01-01')],
+            0,
+            'No events updated after 2100',
         ];
 
         // Test IdFilter.

--- a/tests/ApiPlatform/EventsTest.php
+++ b/tests/ApiPlatform/EventsTest.php
@@ -2,7 +2,9 @@
 
 namespace App\Tests\ApiPlatform;
 
+use App\Api\Dto\Event;
 use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
+use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
 
 /**
  * Test that we can call the API.
@@ -10,6 +12,11 @@ use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
 class EventsTest extends AbstractApiTestCase
 {
     use GetEntitiesTestTrait;
+    use GetItemTestTrait;
 
     protected static string $requestPath = '/api/v2/events';
+
+    protected static string $resourceClass = Event::class;
+
+    protected static int|string $itemId = 7;
 }

--- a/tests/ApiPlatform/FilterErrorTest.php
+++ b/tests/ApiPlatform/FilterErrorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Verify the contract for malformed filter input.
+ *
+ * The DateRangeFilter on the Event, Occurrence, DailyOccurrence, Location and
+ * Organization resources is configured with `throwOnInvalid: true`, so a
+ * malformed value must surface as a client error (4xx) rather than a 5xx leak,
+ * and the response body must follow RFC 7807 (problem+json) per
+ * `rfc_7807_compliant_errors: true` in api_platform.yaml.
+ */
+class FilterErrorTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/events';
+
+    #[DataProvider('invalidDateRangeProvider')]
+    public function testInvalidDateRangeReturnsClientError(string $path, array $query, string $message): void
+    {
+        // TODO: DateRangeFilter::getElasticSearchQueryRanges() throws PHP's
+        // native \InvalidArgumentException, which is not in api_platform.yaml's
+        // exception_to_status map, so the framework returns 500 instead of 400.
+        // Either map \InvalidArgumentException -> 400, or throw
+        // ApiPlatform\Exception\InvalidArgumentException. Once fixed, remove
+        // this skip — the assertions below already encode the desired contract.
+        $this->markTestSkipped('Known contract bug: malformed date range returns 5xx. See TODO.');
+
+        // @phpstan-ignore-next-line deadCode.unreachable
+        $response = $this->get($query, $path);
+        $statusCode = $response->getStatusCode();
+        $this->assertGreaterThanOrEqual(400, $statusCode, $message.': '.$statusCode);
+        $this->assertLessThan(500, $statusCode, 'Filter errors must not leak as 5xx — '.$message);
+    }
+
+    public static function invalidDateRangeProvider(): iterable
+    {
+        // Missing '..' separator → DateRangeFilter throws \InvalidArgumentException('Invalid date range').
+        yield 'events: missing separator' => [
+            '/api/v2/events',
+            ['occurrences.start[between]' => '2024-01-01T00:00:00+00:00'],
+            'Between filter without ".." separator',
+        ];
+
+        // Too many '..' segments.
+        yield 'events: three segments' => [
+            '/api/v2/events',
+            ['occurrences.start[between]' => '2024-01-01T00:00:00+00:00..2024-06-01T00:00:00+00:00..2024-12-31T00:00:00+00:00'],
+            'Between filter with three segments',
+        ];
+
+        yield 'occurrences: missing separator' => [
+            '/api/v2/occurrences',
+            ['start[between]' => '2024-01-01T00:00:00+00:00'],
+            'Between filter on occurrences without ".." separator',
+        ];
+
+        yield 'daily_occurrences: missing separator' => [
+            '/api/v2/daily_occurrences',
+            ['start[between]' => '2024-01-01T00:00:00+00:00'],
+            'Between filter on daily_occurrences without ".." separator',
+        ];
+    }
+}

--- a/tests/ApiPlatform/LocationsFilterTest.php
+++ b/tests/ApiPlatform/LocationsFilterTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test that filtering locations work as expected.
+ */
+class LocationsFilterTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/locations';
+
+    #[DataProvider('getLocationsProvider')]
+    public function testGetLocations(array $query, int $expectedCount, ?string $message = null): void
+    {
+        $message ??= '';
+
+        $response = $this->get($query);
+
+        $data = $response->toArray();
+        $this->assertArrayHasKey('hydra:member', $data, $message);
+        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+    }
+
+    public static function getLocationsProvider(): iterable
+    {
+        // Unfiltered.
+        yield [[], 2];
+
+        // MatchFilter on name.
+        yield [['name' => 'ITK Development'], 1, 'Location named "ITK Development"'];
+        yield [['name' => 'Somewhere'], 1, 'Location named "Somewhere"'];
+        yield [['name' => 'nonexistent'], 0];
+
+        // MatchFilter on postalCode.
+        yield [['postalCode' => '8000'], 1, 'Location with postal code 8000'];
+        yield [['postalCode' => '9999'], 0];
+    }
+}

--- a/tests/ApiPlatform/LocationsTest.php
+++ b/tests/ApiPlatform/LocationsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use App\Api\Dto\Location;
+use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
+use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
+
+class LocationsTest extends AbstractApiTestCase
+{
+    use GetEntitiesTestTrait;
+    use GetItemTestTrait;
+
+    protected static string $requestPath = '/api/v2/locations';
+
+    protected static string $resourceClass = Location::class;
+
+    protected static int|string $itemId = 4;
+}

--- a/tests/ApiPlatform/OccurrencesFilterTest.php
+++ b/tests/ApiPlatform/OccurrencesFilterTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test that filtering occurrences work as expected.
+ */
+class OccurrencesFilterTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/occurrences';
+
+    #[DataProvider('getOccurrencesProvider')]
+    public function testGetOccurrences(array $query, int $expectedCount, ?string $message = null): void
+    {
+        $message ??= '';
+
+        $response = $this->get($query);
+
+        $data = $response->toArray();
+        $this->assertArrayHasKey('hydra:member', $data, $message);
+        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+    }
+
+    public static function getOccurrencesProvider(): iterable
+    {
+        // Unfiltered.
+        yield [[], 3];
+
+        // DateRangeFilter on start.
+        yield [
+            ['start[between]' => static::formatDateTime('2024-12-01').'..'.static::formatDateTime('2024-12-31')],
+            2,
+            'Occurrences starting in December 2024',
+        ];
+
+        yield [
+            ['start[between]' => static::formatDateTime('2024-11-01').'..'.static::formatDateTime('2024-11-30')],
+            1,
+            'Occurrences starting in November 2024',
+        ];
+
+        // DateRangeFilter on end.
+        yield [
+            ['end[between]' => static::formatDateTime('2024-12-07').'..'.static::formatDateTime('2024-12-09')],
+            2,
+            'Occurrences ending around 2024-12-08',
+        ];
+
+        // MatchFilter on event.title. MatchFilter is token-based (ES word match),
+        // so all three fixture events contain the shared tokens "ITKDev/test/event".
+        // To narrow we'd need a token unique to a single record.
+        yield [
+            ['event.title' => 'ITKDev'],
+            3,
+            'All fixture events have "ITKDev" in the title',
+        ];
+
+        yield [
+            ['event.title' => 'totallyuniqueword'],
+            0,
+            'Token absent from all titles returns no occurrences',
+        ];
+
+        // MatchFilter on event.organizer.name.
+        yield [
+            ['event.organizer.name' => 'ITKDev'],
+            3,
+            'Occurrences organized by ITKDev',
+        ];
+
+        // MatchFilter on event.location.name.
+        yield [
+            ['event.location.name' => 'ITK Development'],
+            3,
+            'Occurrences at ITK Development',
+        ];
+
+        // IdFilter on event.organizer.entityId.
+        yield [
+            ['event.organizer.entityId' => 9],
+            3,
+        ];
+
+        yield [
+            ['event.organizer.entityId' => 99],
+            0,
+        ];
+
+        // IdFilter on event.location.entityId.
+        yield [
+            ['event.location.entityId' => 4],
+            3,
+        ];
+
+        // TagFilter on event.tags.
+        yield [
+            ['event.tags' => 'itkdev'],
+            1,
+            'Occurrences for events tagged "itkdev"',
+        ];
+
+        yield [
+            ['event.tags' => 'unknown-tag'],
+            0,
+        ];
+    }
+}

--- a/tests/ApiPlatform/OccurrencesTest.php
+++ b/tests/ApiPlatform/OccurrencesTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use App\Api\Dto\Occurrence;
+use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
+use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
+
+class OccurrencesTest extends AbstractApiTestCase
+{
+    use GetEntitiesTestTrait;
+    use GetItemTestTrait;
+
+    protected static string $requestPath = '/api/v2/occurrences';
+
+    protected static string $resourceClass = Occurrence::class;
+
+    protected static int|string $itemId = 10;
+}

--- a/tests/ApiPlatform/OrganizationsFilterTest.php
+++ b/tests/ApiPlatform/OrganizationsFilterTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test that filtering organizations work as expected.
+ */
+class OrganizationsFilterTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/organizations';
+
+    #[DataProvider('getOrganizationsProvider')]
+    public function testGetOrganizations(array $query, int $expectedCount, ?string $message = null): void
+    {
+        $message ??= '';
+
+        $response = $this->get($query);
+
+        $data = $response->toArray();
+        $this->assertArrayHasKey('hydra:member', $data, $message);
+        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+    }
+
+    public static function getOrganizationsProvider(): iterable
+    {
+        // Unfiltered.
+        yield [[], 3];
+
+        // MatchFilter on name.
+        yield [['name' => 'ITKDev'], 1, 'Organization named "ITKDev"'];
+        yield [['name' => 'Dokk1'], 1];
+        yield [['name' => 'Aakb'], 1];
+        yield [['name' => 'nonexistent'], 0];
+    }
+}

--- a/tests/ApiPlatform/OrganizationsTest.php
+++ b/tests/ApiPlatform/OrganizationsTest.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use App\Api\Dto\Organization;
+use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
+use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
+
+class OrganizationsTest extends AbstractApiTestCase
+{
+    use GetEntitiesTestTrait;
+    use GetItemTestTrait;
+
+    protected static string $requestPath = '/api/v2/organizations';
+
+    protected static string $resourceClass = Organization::class;
+
+    protected static int|string $itemId = 9;
+}

--- a/tests/ApiPlatform/PaginationTest.php
+++ b/tests/ApiPlatform/PaginationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Verify the pagination contract: itemsPerPage client override, max clamp,
+ * default counts, and hydra:view navigation links.
+ */
+class PaginationTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/events';
+
+    #[DataProvider('resourceProvider')]
+    public function testCollectionExposesHydraKeys(string $path, int $fixtureCount, int $maxPerPage): void
+    {
+        unset($maxPerPage);
+
+        $response = $this->get([], $path);
+        $data = $response->toArray();
+
+        $this->assertArrayHasKey('hydra:member', $data);
+        $this->assertArrayHasKey('hydra:totalItems', $data);
+        $this->assertSame($fixtureCount, $data['hydra:totalItems'], $path.' should report '.$fixtureCount.' total items');
+    }
+
+    #[DataProvider('resourceProvider')]
+    public function testItemsPerPageClientOverride(string $path, int $fixtureCount, int $maxPerPage): void
+    {
+        unset($maxPerPage);
+
+        if ($fixtureCount < 2) {
+            $this->markTestSkipped($path.' has < 2 fixtures — cannot test itemsPerPage=1 slicing');
+        }
+
+        $response = $this->get(['itemsPerPage' => 1], $path);
+        $data = $response->toArray();
+
+        $this->assertCount(1, $data['hydra:member'], $path.' should honour itemsPerPage=1');
+        $this->assertSame($fixtureCount, $data['hydra:totalItems']);
+    }
+
+    #[DataProvider('resourceProvider')]
+    public function testItemsPerPageRespectsMaximum(string $path, int $fixtureCount, int $maxPerPage): void
+    {
+        $response = $this->get(['itemsPerPage' => $maxPerPage + 100], $path);
+        $data = $response->toArray();
+
+        $expected = min($fixtureCount, $maxPerPage);
+        $this->assertLessThanOrEqual($maxPerPage, count($data['hydra:member']), $path.' must clamp itemsPerPage to '.$maxPerPage);
+        $this->assertCount($expected, $data['hydra:member']);
+    }
+
+    public function testPageNavigationLinksPresentWhenSliced(): void
+    {
+        $response = $this->get(['itemsPerPage' => 1, 'page' => 1], '/api/v2/events');
+        $data = $response->toArray();
+
+        $this->assertArrayHasKey('hydra:view', $data, 'Multi-page result must expose hydra:view');
+        $view = $data['hydra:view'];
+
+        $this->assertArrayHasKey('hydra:next', $view, 'Page 1 of 3 should expose hydra:next');
+        $this->assertArrayHasKey('hydra:last', $view);
+
+        $response = $this->get(['itemsPerPage' => 1, 'page' => 3], '/api/v2/events');
+        $data = $response->toArray();
+        $this->assertArrayHasKey('hydra:view', $data);
+        $this->assertArrayHasKey('hydra:previous', $data['hydra:view'], 'Page 3 of 3 should expose hydra:previous');
+    }
+
+    public static function resourceProvider(): iterable
+    {
+        // [path, fixture count, paginationMaximumItemsPerPage]
+        yield 'events' => ['/api/v2/events', 3, 50];
+        yield 'occurrences' => ['/api/v2/occurrences', 3, 50];
+        yield 'daily_occurrences' => ['/api/v2/daily_occurrences', 3, 50];
+        yield 'locations' => ['/api/v2/locations', 2, 100];
+        yield 'organizations' => ['/api/v2/organizations', 3, 100];
+        yield 'tags' => ['/api/v2/tags', 5, 100];
+        yield 'vocabularies' => ['/api/v2/vocabularies', 2, 100];
+    }
+}

--- a/tests/ApiPlatform/TagsFilterTest.php
+++ b/tests/ApiPlatform/TagsFilterTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test that filtering tags work as expected.
+ */
+class TagsFilterTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/tags';
+
+    #[DataProvider('getTagsProvider')]
+    public function testGetTags(array $query, int $expectedCount, ?string $message = null): void
+    {
+        $message ??= '';
+
+        $response = $this->get($query);
+
+        $data = $response->toArray();
+        $this->assertArrayHasKey('hydra:member', $data, $message);
+        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+    }
+
+    public static function getTagsProvider(): iterable
+    {
+        // Unfiltered.
+        yield [[], 5];
+
+        // MatchFilter on name.
+        yield [['name' => 'aros'], 1, 'Tag named "aros"'];
+        yield [['name' => 'Koncert'], 1];
+        yield [['name' => 'nonexistent'], 0];
+
+        // MatchFilter on vocabulary.
+        yield [['vocabulary' => 'aarhusguiden'], 5, 'All fixture tags belong to the aarhusguiden vocabulary'];
+        yield [['vocabulary' => 'feeds'], 0];
+    }
+}

--- a/tests/ApiPlatform/TagsTest.php
+++ b/tests/ApiPlatform/TagsTest.php
@@ -2,7 +2,9 @@
 
 namespace App\Tests\ApiPlatform;
 
+use App\Api\Dto\Tag;
 use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
+use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
 
 /**
  * Test that we can call the API.
@@ -10,6 +12,13 @@ use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
 class TagsTest extends AbstractApiTestCase
 {
     use GetEntitiesTestTrait;
+    use GetItemTestTrait;
 
     protected static string $requestPath = '/api/v2/tags';
+
+    protected static string $resourceClass = Tag::class;
+
+    protected static int|string $itemId = 'aros';
+
+    protected static int|string $unknownItemId = 'no-such-tag-slug';
 }

--- a/tests/ApiPlatform/Trait/GetEntitiesTestTrait.php
+++ b/tests/ApiPlatform/Trait/GetEntitiesTestTrait.php
@@ -19,5 +19,13 @@ trait GetEntitiesTestTrait
         $this->assertResponseStatusCodeSame(Response::HTTP_OK);
         $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
         $this->assertJson($response->getContent());
+
+        $data = $response->toArray();
+        $this->assertArrayHasKey('hydra:member', $data);
+        $this->assertArrayHasKey('hydra:totalItems', $data);
+
+        if (isset(static::$resourceClass)) {
+            $this->assertMatchesResourceCollectionJsonSchema(static::$resourceClass);
+        }
     }
 }

--- a/tests/ApiPlatform/Trait/GetItemTestTrait.php
+++ b/tests/ApiPlatform/Trait/GetItemTestTrait.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Tests\ApiPlatform\Trait;
+
+use App\Tests\ApiPlatform\AbstractApiTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+trait GetItemTestTrait
+{
+    public function testGetItem(): void
+    {
+        assert($this instanceof AbstractApiTestCase);
+
+        $path = static::$requestPath.'/'.static::$itemId;
+
+        $this->get([], $path, authenticated: false);
+        $this->assertResponseStatusCodeSame(Response::HTTP_UNAUTHORIZED);
+
+        $response = $this->get([], $path);
+        $this->assertResponseStatusCodeSame(Response::HTTP_OK);
+        $this->assertResponseHeaderSame('content-type', 'application/ld+json; charset=utf-8');
+        $this->assertJson($response->getContent());
+        $this->assertMatchesResourceItemJsonSchema(static::$resourceClass);
+    }
+
+    public function testGetItemNotFound(): void
+    {
+        assert($this instanceof AbstractApiTestCase);
+
+        $path = static::$requestPath.'/'.static::$unknownItemId;
+
+        $this->get([], $path);
+        $this->assertResponseStatusCodeSame(Response::HTTP_NOT_FOUND);
+    }
+}

--- a/tests/ApiPlatform/VocabulariesFilterTest.php
+++ b/tests/ApiPlatform/VocabulariesFilterTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Test that filtering vocabularies work as expected.
+ */
+class VocabulariesFilterTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/vocabularies';
+
+    #[DataProvider('getVocabulariesProvider')]
+    public function testGetVocabularies(array $query, int $expectedCount, ?string $message = null): void
+    {
+        $message ??= '';
+
+        $response = $this->get($query);
+
+        $data = $response->toArray();
+        $this->assertArrayHasKey('hydra:member', $data, $message);
+        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+    }
+
+    public static function getVocabulariesProvider(): iterable
+    {
+        // Unfiltered.
+        yield [[], 2];
+
+        // MatchFilter on name.
+        yield [['name' => 'aarhusguiden'], 1];
+        yield [['name' => 'feeds'], 1];
+        yield [['name' => 'nonexistent'], 0];
+
+        // MatchFilter on tags.
+        yield [['tags' => 'aros'], 1, 'aarhusguiden vocabulary contains the "aros" tag'];
+        yield [['tags' => 'unknown-tag'], 0];
+    }
+}

--- a/tests/ApiPlatform/VocabulariesTest.php
+++ b/tests/ApiPlatform/VocabulariesTest.php
@@ -2,7 +2,9 @@
 
 namespace App\Tests\ApiPlatform;
 
+use App\Api\Dto\Vocabulary;
 use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
+use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
 
 /**
  * Test that we can call the API.
@@ -10,6 +12,13 @@ use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
 class VocabulariesTest extends AbstractApiTestCase
 {
     use GetEntitiesTestTrait;
+    use GetItemTestTrait;
 
     protected static string $requestPath = '/api/v2/vocabularies';
+
+    protected static string $resourceClass = Vocabulary::class;
+
+    protected static int|string $itemId = 'aarhusguiden';
+
+    protected static int|string $unknownItemId = 'no-such-vocabulary-slug';
 }


### PR DESCRIPTION
Grow the test suite into a **behavioural contract** for the API so the upcoming API Platform upgrade can't introduce silent regressions or BC breaks. **Tests only — no API code is changed.**

## Changes

Builds on the existing per-resource work (GET collection/item, filter matrices, pagination, auth, filter-errors) and adds a `tests/ApiPlatform/Contract/` suite that pins the wire contract **independently of API Platform's self-generated JSON schema** (that schema regenerates *with* the upgrade, so schema-based assertions can't catch envelope/field changes):

- **`CollectionContractTest`** — JSON-LD/Hydra collection envelope (`@context`/`@id`/`@type`/`hydra:totalItems`/`hydra:member`/`hydra:search`) and the **exact member field set** of all 7 resources.
- **`ItemContractTest`** — the item ("GET one") shape, including the current asymmetry (see bugs below).
- **`ErrorContractTest`** — `hydra:Error` shape for 401/404 (`status`/`type`/`title`/`detail`).
- **`ContentNegotiationContractTest`** — only `application/ld+json` is served; `application/json`/`text/html` → 406.
- **`DateFormatContractTest`** — ISO 8601 with timezone offset.

**164 tests, 443 assertions, 4 skipped**; php-cs-fixer + phpstan (level 8) clean.

## Bugs / quirks surfaced (NOT fixed here — see "no BC changes" advice)

These are locked by the new tests **as current behaviour**, so if the upgrade changes them, CI fails loudly:

1. **Item endpoints return a `hydra:Collection` wrapper of one** for Event/Occurrence/DailyOccurrence/Location/Organization (not a single JSON-LD item), and those members carry **no `@id`/`@type`**. Tag/Vocabulary instead return a proper flat item with `@id`/`@type`. → *Highest BC risk:* an upgrade may "normalise" this to standard item output. That would be a **BC break for consumers** — the tests will catch it; the team must then decide to preserve the quirk (custom state/normalizer) or coordinate the change with API clients.
2. **Malformed `[between]` date range → HTTP 500** (already documented, `FilterErrorTest`, skipped). A native `\InvalidArgumentException` isn't in `exception_to_status`, so it leaks as 5xx instead of 4xx. Behaviour may shift on upgrade; fix belongs in a separate PR.
3. **Only `application/ld+json` is negotiable** — `application/json` yields 406. Fine if intended, but a format-negotiation change on upgrade would be client-visible; now pinned.
4. **Error bodies include a full `trace`** in debug/test env — env-dependent (not asserted), but worth confirming debug is off in prod so stack traces don't leak.

## Notes
- The only non-test file is the CHANGELOG entry (required by the `changelog` CI check).
- The 4 skips are the `FilterErrorTest` rows for bug #2, kept as executable documentation of the intended 4xx contract.