### PR TITLE
test: apply production-parity Elasticsearch mappings in the test harness

### DIFF
--- a/.claude/agents/filter-provider-reviewer.md
+++ b/.claude/agents/filter-provider-reviewer.md
@@ -18,10 +18,14 @@ Focus your review on:
    `SortFilterInterface` marker. A new sorting filter must implement that marker or it will be treated as a query
    clause; a query filter must not.
 
-3. **Index-contract alignment.** Field names/types referenced in the DSL must match what `event-database-imports`
-   writes (mappings live only there — this repo has none). A typo'd or renamed field yields empty/incorrect results
-   silently, not an error. Flag any field reference you can't confirm against the index contract and recommend
-   verifying against a live mapping (`docker compose exec -T phpfpm curl -s http://elasticsearch:9200/<index>/_mapping`).
+3. **Index-contract alignment — check the MAPPED field type, not assumed behaviour.** Field names/types referenced
+   in the DSL must match what `event-database-imports` writes. The production-parity mappings are copied in
+   `tests/resources/mappings/*.json` — consult them. Matching semantics depend on the mapped type: a `keyword` field
+   (e.g. `tags`, `slug`, `vocabulary`, `postalCode`) matches **exact, case-sensitive, whole-value** (no tokenisation);
+   a `text` field (e.g. `title`, `name`, `description`) is **tokenised** (word match). Do not assume dynamic-mapping
+   behaviour. A typo'd/renamed field, or a filter that assumes token matching on a `keyword` field, yields
+   empty/incorrect results silently — not an error. Confirm against `tests/resources/mappings/<index>.json` or a live
+   mapping (`docker compose exec -T phpfpm curl -s http://elasticsearch:9200/<index>/_mapping`).
 
 4. **Pagination & limits.** `paginationMaximumItemsPerPage` on the DTO and `AbstractProvider::MAX_PAGE_SIZE_FALLBACK`
    (20) bound page size — check a new provider respects them and returns `SearchResults` for collections / a single

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-35](https://github.com/itk-dev/event-database-api/pull/35)
+  Test against production-parity Elasticsearch mappings (dynamic: strict) so filter tests exercise real field semantics
 - [PR-33](https://github.com/itk-dev/event-database-api/pull/33)
   Mature the API test suite ahead of the API Platform upgrade (contract, filter, pagination and error tests)
 - [PR-32](https://github.com/itk-dev/event-database-api/pull/32)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,12 @@ Tests hit a real Elasticsearch (no mocking) — see `tests/ApiPlatform/AbstractA
 API key is `test_api_key`. If a test run dies with "No alive nodes", run `docker compose up --detach --wait` and
 reload fixtures.
 
+The test harness creates each index with a **production-parity mapping** (`dynamic: strict`) checked in at
+`tests/resources/mappings/<index>.json` — a hand-kept copy of the importer's `src/Model/Indexing/Mappings/`.
+`FixtureLoader::createIndex()` fails loudly if a mapping is missing, so the filter tests exercise real field
+semantics (`keyword` = exact/case-sensitive; `text` = tokenised) rather than Elasticsearch dynamic-mapping
+artefacts. When the importer changes a mapping, update the matching file here (the `Stop` hook warns on drift).
+
 ### Lint / static analysis
 
 ```shell

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,8 +38,6 @@ tasks:
         task: compose
         vars:
           COMPOSE_ARGS: exec phpfpm bin/console app:fixtures:load {{.ITEM}}
-    # Loading some fixtures generates an 'Warning: Undefined array key "entityId"' error.
-    ignore_error: true
     silent: true
 
   fixtures:load:test:
@@ -57,8 +55,6 @@ tasks:
         task: compose
         vars:
           COMPOSE_ARGS: exec phpfpm bin/console app:fixtures:load {{.ITEM}} --url=file:///app/tests/resources/{{.ITEM}}.json
-    # Loading some fixtures generates an 'Warning: Undefined array key "entityId"' error.
-    ignore_error: true
 
   composer:
     desc: "Run `composer` command. Example: task composer -- normalize"

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -56,6 +56,10 @@ services:
         arguments:
             $appEnv: '%env(string:APP_ENV)%'
 
+    App\Fixtures\FixtureLoader:
+        arguments:
+            $mappingsDir: '%kernel.project_dir%/tests/resources/mappings'
+
     App\Security\ApiUserProvider:
         arguments:
             $apikeys: '%env(json:APP_API_KEYS)%'

--- a/scripts/claude-hook-check-index-contract.sh
+++ b/scripts/claude-hook-check-index-contract.sh
@@ -4,23 +4,25 @@
 # event-database-imports WRITES the ES indices; this repo (event-database-api)
 # READS them. The contract (index-name enum + document field names/types) is
 # duplicated by hand across both repos with no compile-time link. This repo owns
-# only the index-name enum; the document mappings live solely in the importer.
-# See CLAUDE.md -> "Works with event-database-imports".
+# the index-name enum (src/Model/IndexName.php) and a production-parity COPY of
+# the importer's mappings (tests/resources/mappings/) that the test harness
+# applies. See CLAUDE.md -> "Works with event-database-imports".
 set -u
 
 cd "${CLAUDE_PROJECT_DIR:-.}" || exit 0
 
 CHANGED="$(git status --porcelain 2>/dev/null | awk '{print $NF}')"
 
-echo "$CHANGED" | grep -qE '^src/Model/IndexName\.php' || exit 0
+echo "$CHANGED" | grep -qE '^(src/Model/IndexName\.php|tests/resources/mappings/)' || exit 0
 
 cat >&2 <<'MSG'
-WARN: the Elasticsearch index-name enum changed (src/Model/IndexName.php).
-      event-database-imports writes these indices and duplicates the contract by
-      hand in its src/Model/Indexing/IndexNames.php. An index name that does not
-      match what the importer creates (and populates behind the queried alias)
-      yields an empty or failing API resource. Coordinate the change with
-      event-database-imports before deploying.
+WARN: the Elasticsearch index contract changed (src/Model/IndexName.php or
+      tests/resources/mappings/). event-database-imports owns the source of
+      truth: index names in its src/Model/Indexing/IndexNames.php and mappings in
+      src/Model/Indexing/Mappings/. A name or field/type that diverges from what
+      the importer creates yields empty or failing API resources, and stale test
+      mappings make the filter suite green for semantics production does not have.
+      Reconcile against event-database-imports before deploying.
 MSG
 
 exit 0

--- a/src/Fixtures/FixtureLoader.php
+++ b/src/Fixtures/FixtureLoader.php
@@ -22,6 +22,7 @@ class FixtureLoader
         private readonly HttpClientInterface $httpClient,
         private readonly IndexInterface $index,
         private readonly Client $client,
+        private readonly string $mappingsDir,
     ) {
     }
 
@@ -140,19 +141,37 @@ class FixtureLoader
      */
     private function createIndex(string $indexName): void
     {
-        if (!$this->index->indexExists($indexName)) {
-            // This creation of the index is not in den index service as this is the only place it should be used. In
-            // production and in many cases, you should connect to the index managed by the backend (imports).
-            $this->client->indices()->create([
-                'index' => $indexName,
-                'body' => [
-                    'settings' => [
-                        'number_of_shards' => 5,
-                        'number_of_replicas' => 0,
-                    ],
-                ],
-            ]);
+        if ($this->index->indexExists($indexName)) {
+            return;
         }
+
+        // This creation of the index is not in the index service as this is the only place it should be used. In
+        // production you connect to the index managed by the backend (imports). The mapping applied here is a
+        // production-parity copy of the importer's `dynamic: strict` mappings (tests/resources/mappings/), so filter
+        // tests exercise real Elasticsearch field semantics (keyword vs text) instead of dynamic-mapping artefacts.
+        $mappingFile = $this->mappingsDir.'/'.$indexName.'.json';
+        if (!is_readable($mappingFile)) {
+            throw new \RuntimeException(sprintf('Missing production-parity mapping for index "%s" (expected %s). Export it from event-database-imports (src/Model/Indexing/Mappings); the test harness must never create an index with dynamic mapping.', $indexName, $mappingFile));
+        }
+        $contents = file_get_contents($mappingFile);
+        if (false === $contents) {
+            throw new \RuntimeException(sprintf('Unable to read mapping file %s', $mappingFile));
+        }
+        $mappings = json_decode($contents, true);
+        if (!is_array($mappings)) {
+            throw new \RuntimeException(sprintf('Invalid mapping JSON in %s', $mappingFile));
+        }
+
+        $this->client->indices()->create([
+            'index' => $indexName,
+            'body' => [
+                'settings' => [
+                    'number_of_shards' => 5,
+                    'number_of_replicas' => 0,
+                ],
+                'mappings' => $mappings,
+            ],
+        ]);
     }
 
     /**

--- a/tests/ApiPlatform/DailyOccurrencesFilterTest.php
+++ b/tests/ApiPlatform/DailyOccurrencesFilterTest.php
@@ -53,9 +53,9 @@ class DailyOccurrencesFilterTest extends AbstractApiTestCase
             3,
         ];
 
-        // TagFilter on event.tags.
+        // TagFilter on event.tags — keyword field, exact/case-sensitive match.
         yield [
-            ['event.tags' => 'itkdev'],
+            ['event.tags' => 'ITKDev'],
             1,
         ];
 

--- a/tests/ApiPlatform/EventsFilterTest.php
+++ b/tests/ApiPlatform/EventsFilterTest.php
@@ -90,11 +90,36 @@ class EventsFilterTest extends AbstractApiTestCase
             0,
         ];
 
-        // Test TagFilter.
+        // Test TagFilter. In production `tags` is a keyword field (see event-database-imports
+        // Mappings/Event) — matching is exact, case-sensitive and whole-value (no tokenisation).
+        yield [
+            ['tags' => 'ITKDev'],
+            2,
+            'Events tagged with "ITKDev" (exact keyword match)',
+        ];
+
         yield [
             ['tags' => 'itkdev'],
-            2,
-            'Events tagged with "itkdev"',
+            0,
+            'Tag matching is case-sensitive: "itkdev" does not match "ITKDev"',
+        ];
+
+        yield [
+            ['tags' => 'aros'],
+            3,
+            'All fixture events are tagged "aros"',
+        ];
+
+        yield [
+            ['tags' => 'for-boern'],
+            1,
+            'A hyphenated tag matches as a whole value, not by token',
+        ];
+
+        yield [
+            ['tags' => 'boern'],
+            0,
+            'No substring/token match on a keyword field',
         ];
 
         yield [
@@ -103,42 +128,14 @@ class EventsFilterTest extends AbstractApiTestCase
             'Events tagged with "itkdevelopment"',
         ];
 
-        // @todo Does tags filtering use the tag slug or name?
-        // yield [
-        //   ['tags' => 'for børn'],
-        //   0,
-        //   'Events tagged with "for børn"',
-        // ];
-        //
-        // yield [
-        //   ['tags' => 'for-boern'],
-        //   1,
-        //   'Events tagged with "for-boern"',
-        // ];
-
-        // @todo It seems that filtering in tags use som sort of "contains word"
-        // stuff, i.e. we can match the tag "for-boern" by filtering on "boern"
-        // or on "for" – but not on "for-boern" …
-        yield [
-            ['tags' => 'boern'],
-            1,
-            'Events tagged with "boern"',
-        ];
-
-        yield [
-            ['tags' => 'for'],
-            2,
-            'Events tagged with "for"',
-        ];
-
         // Combined filters.
         yield [
             [
                 'occurrences.start[between]' => static::formatDateTime('2026-01-01').'..'.static::formatDateTime('2026-12-31'),
-                'tags' => 'itkdev',
+                'tags' => 'aros',
             ],
             1,
-            'Events in 2026 tagged with "itkdev"',
+            'Events in 2026 also tagged "aros"',
         ];
     }
 }

--- a/tests/ApiPlatform/OccurrencesFilterTest.php
+++ b/tests/ApiPlatform/OccurrencesFilterTest.php
@@ -48,8 +48,9 @@ class OccurrencesFilterTest extends AbstractApiTestCase
             'Occurrences ending around 2024-12-08',
         ];
 
-        // MatchFilter on event.title. MatchFilter is token-based (ES word match),
-        // so all three fixture events contain the shared tokens "ITKDev/test/event".
+        // MatchFilter on event.title. `title` is a `text` field in production (see
+        // event-database-imports Mappings/Event), so ES tokenises it and this is a word
+        // match — all three fixture events share the tokens "ITKDev/test/event".
         // To narrow we'd need a token unique to a single record.
         yield [
             ['event.title' => 'ITKDev'],
@@ -94,11 +95,11 @@ class OccurrencesFilterTest extends AbstractApiTestCase
             3,
         ];
 
-        // TagFilter on event.tags.
+        // TagFilter on event.tags — keyword field, exact/case-sensitive match.
         yield [
-            ['event.tags' => 'itkdev'],
+            ['event.tags' => 'ITKDev'],
             1,
-            'Occurrences for events tagged "itkdev"',
+            'Occurrences for events tagged "ITKDev"',
         ];
 
         yield [

--- a/tests/resources/mappings/daily_occurrences.json
+++ b/tests/resources/mappings/daily_occurrences.json
@@ -1,0 +1,419 @@
+{
+    "dynamic": "strict",
+    "properties": {
+        "entityId": {
+            "type": "integer",
+            "doc_values": false
+        },
+        "start": {
+            "type": "date",
+            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+            "index": false,
+            "doc_values": true
+        },
+        "end": {
+            "type": "date",
+            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+            "index": false,
+            "doc_values": true
+        },
+        "ticketPriceRange": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "room": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "status": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "event": {
+            "properties": {
+                "entityId": {
+                    "type": "integer",
+                    "doc_values": false
+                },
+                "title": {
+                    "type": "text",
+                    "analyzer": "standard",
+                    "search_analyzer": "standard",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword"
+                        }
+                    },
+                    "index_options": "docs",
+                    "index": true,
+                    "norms": false,
+                    "fielddata": true
+                },
+                "excerpt": {
+                    "type": "text",
+                    "index_options": "docs",
+                    "index": false,
+                    "norms": false
+                },
+                "description": {
+                    "type": "text",
+                    "index_options": "docs",
+                    "index": true,
+                    "norms": false
+                },
+                "url": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "ticketUrl": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "imageUrls": {
+                    "properties": {
+                        "small": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "medium": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "large": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        }
+                    }
+                },
+                "publicAccess": {
+                    "type": "boolean",
+                    "index": true,
+                    "doc_values": false
+                },
+                "created": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                },
+                "updated": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                },
+                "tags": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": true,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "organizer": {
+                    "properties": {
+                        "entityId": {
+                            "type": "integer",
+                            "doc_values": false
+                        },
+                        "name": {
+                            "type": "text",
+                            "analyzer": "standard",
+                            "search_analyzer": "standard",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword"
+                                }
+                            },
+                            "index_options": "docs",
+                            "index": true,
+                            "norms": false,
+                            "fielddata": true
+                        },
+                        "email": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "url": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "created": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "updated": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        }
+                    }
+                },
+                "partners": {
+                    "properties": {
+                        "entityId": {
+                            "type": "integer",
+                            "doc_values": false
+                        },
+                        "name": {
+                            "type": "text",
+                            "analyzer": "standard",
+                            "search_analyzer": "standard",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword"
+                                }
+                            },
+                            "index_options": "docs",
+                            "index": true,
+                            "norms": false,
+                            "fielddata": true
+                        },
+                        "email": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "url": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "created": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "updated": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        }
+                    }
+                },
+                "location": {
+                    "properties": {
+                        "entityId": {
+                            "type": "integer",
+                            "doc_values": false
+                        },
+                        "name": {
+                            "type": "text",
+                            "analyzer": "standard",
+                            "search_analyzer": "standard",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword"
+                                }
+                            },
+                            "index_options": "docs",
+                            "index": true,
+                            "norms": false,
+                            "fielddata": true
+                        },
+                        "image": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "url": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "telephone": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "disabilityAccess": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "mail": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "city": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "street": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "suite": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "region": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "postalCode": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": true,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "country": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "coordinates": {
+                            "type": "geo_point"
+                        }
+                    }
+                },
+                "occurrences": {
+                    "properties": {
+                        "entityId": {
+                            "type": "integer",
+                            "doc_values": false
+                        },
+                        "start": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "end": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "ticketPriceRange": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "room": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "status": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        }
+                    }
+                },
+                "dailyOccurrences": {
+                    "properties": {
+                        "entityId": {
+                            "type": "integer",
+                            "doc_values": false
+                        },
+                        "start": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "end": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "ticketPriceRange": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "room": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "status": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/resources/mappings/events.json
+++ b/tests/resources/mappings/events.json
@@ -1,0 +1,378 @@
+{
+    "dynamic": "strict",
+    "properties": {
+        "entityId": {
+            "type": "integer",
+            "doc_values": false
+        },
+        "title": {
+            "type": "text",
+            "analyzer": "standard",
+            "search_analyzer": "standard",
+            "fields": {
+                "keyword": {
+                    "type": "keyword"
+                }
+            },
+            "index_options": "docs",
+            "index": true,
+            "norms": false,
+            "fielddata": true
+        },
+        "excerpt": {
+            "type": "text",
+            "index_options": "docs",
+            "index": false,
+            "norms": false
+        },
+        "description": {
+            "type": "text",
+            "index_options": "docs",
+            "index": true,
+            "norms": false
+        },
+        "url": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "ticketUrl": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "imageUrls": {
+            "properties": {
+                "small": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "medium": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "large": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                }
+            }
+        },
+        "publicAccess": {
+            "type": "boolean",
+            "index": true,
+            "doc_values": false
+        },
+        "created": {
+            "type": "date",
+            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+            "index": false,
+            "doc_values": true
+        },
+        "updated": {
+            "type": "date",
+            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+            "index": false,
+            "doc_values": true
+        },
+        "tags": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": true,
+            "doc_values": false,
+            "norms": false
+        },
+        "organizer": {
+            "properties": {
+                "entityId": {
+                    "type": "integer",
+                    "doc_values": false
+                },
+                "name": {
+                    "type": "text",
+                    "analyzer": "standard",
+                    "search_analyzer": "standard",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword"
+                        }
+                    },
+                    "index_options": "docs",
+                    "index": true,
+                    "norms": false,
+                    "fielddata": true
+                },
+                "email": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "url": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "created": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                },
+                "updated": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                }
+            }
+        },
+        "partners": {
+            "properties": {
+                "entityId": {
+                    "type": "integer",
+                    "doc_values": false
+                },
+                "name": {
+                    "type": "text",
+                    "analyzer": "standard",
+                    "search_analyzer": "standard",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword"
+                        }
+                    },
+                    "index_options": "docs",
+                    "index": true,
+                    "norms": false,
+                    "fielddata": true
+                },
+                "email": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "url": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "created": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                },
+                "updated": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                }
+            }
+        },
+        "location": {
+            "properties": {
+                "entityId": {
+                    "type": "integer",
+                    "doc_values": false
+                },
+                "name": {
+                    "type": "text",
+                    "analyzer": "standard",
+                    "search_analyzer": "standard",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword"
+                        }
+                    },
+                    "index_options": "docs",
+                    "index": true,
+                    "norms": false,
+                    "fielddata": true
+                },
+                "image": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "url": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "telephone": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "disabilityAccess": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "mail": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "city": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "street": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "suite": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "region": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "postalCode": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": true,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "country": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "coordinates": {
+                    "type": "geo_point"
+                }
+            }
+        },
+        "occurrences": {
+            "properties": {
+                "entityId": {
+                    "type": "integer",
+                    "doc_values": false
+                },
+                "start": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                },
+                "end": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                },
+                "ticketPriceRange": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "room": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "status": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                }
+            }
+        },
+        "dailyOccurrences": {
+            "properties": {
+                "entityId": {
+                    "type": "integer",
+                    "doc_values": false
+                },
+                "start": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                },
+                "end": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                },
+                "ticketPriceRange": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "room": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "status": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                }
+            }
+        }
+    }
+}

--- a/tests/resources/mappings/locations.json
+++ b/tests/resources/mappings/locations.json
@@ -1,0 +1,103 @@
+{
+    "dynamic": "strict",
+    "properties": {
+        "entityId": {
+            "type": "integer",
+            "doc_values": false
+        },
+        "name": {
+            "type": "text",
+            "analyzer": "standard",
+            "search_analyzer": "standard",
+            "fields": {
+                "keyword": {
+                    "type": "keyword"
+                }
+            },
+            "index_options": "docs",
+            "index": true,
+            "norms": false,
+            "fielddata": true
+        },
+        "image": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "url": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "telephone": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "disabilityAccess": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "mail": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "city": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "street": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "suite": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "region": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "postalCode": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": true,
+            "doc_values": false,
+            "norms": false
+        },
+        "country": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "coordinates": {
+            "type": "geo_point"
+        }
+    }
+}

--- a/tests/resources/mappings/occurrences.json
+++ b/tests/resources/mappings/occurrences.json
@@ -1,0 +1,419 @@
+{
+    "dynamic": "strict",
+    "properties": {
+        "entityId": {
+            "type": "integer",
+            "doc_values": false
+        },
+        "start": {
+            "type": "date",
+            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+            "index": false,
+            "doc_values": true
+        },
+        "end": {
+            "type": "date",
+            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+            "index": false,
+            "doc_values": true
+        },
+        "ticketPriceRange": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "room": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "status": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "event": {
+            "properties": {
+                "entityId": {
+                    "type": "integer",
+                    "doc_values": false
+                },
+                "title": {
+                    "type": "text",
+                    "analyzer": "standard",
+                    "search_analyzer": "standard",
+                    "fields": {
+                        "keyword": {
+                            "type": "keyword"
+                        }
+                    },
+                    "index_options": "docs",
+                    "index": true,
+                    "norms": false,
+                    "fielddata": true
+                },
+                "excerpt": {
+                    "type": "text",
+                    "index_options": "docs",
+                    "index": false,
+                    "norms": false
+                },
+                "description": {
+                    "type": "text",
+                    "index_options": "docs",
+                    "index": true,
+                    "norms": false
+                },
+                "url": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "ticketUrl": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": false,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "imageUrls": {
+                    "properties": {
+                        "small": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "medium": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "large": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        }
+                    }
+                },
+                "publicAccess": {
+                    "type": "boolean",
+                    "index": true,
+                    "doc_values": false
+                },
+                "created": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                },
+                "updated": {
+                    "type": "date",
+                    "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                    "index": false,
+                    "doc_values": true
+                },
+                "tags": {
+                    "type": "keyword",
+                    "index_options": "docs",
+                    "index": true,
+                    "doc_values": false,
+                    "norms": false
+                },
+                "organizer": {
+                    "properties": {
+                        "entityId": {
+                            "type": "integer",
+                            "doc_values": false
+                        },
+                        "name": {
+                            "type": "text",
+                            "analyzer": "standard",
+                            "search_analyzer": "standard",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword"
+                                }
+                            },
+                            "index_options": "docs",
+                            "index": true,
+                            "norms": false,
+                            "fielddata": true
+                        },
+                        "email": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "url": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "created": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "updated": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        }
+                    }
+                },
+                "partners": {
+                    "properties": {
+                        "entityId": {
+                            "type": "integer",
+                            "doc_values": false
+                        },
+                        "name": {
+                            "type": "text",
+                            "analyzer": "standard",
+                            "search_analyzer": "standard",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword"
+                                }
+                            },
+                            "index_options": "docs",
+                            "index": true,
+                            "norms": false,
+                            "fielddata": true
+                        },
+                        "email": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "url": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "created": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "updated": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        }
+                    }
+                },
+                "location": {
+                    "properties": {
+                        "entityId": {
+                            "type": "integer",
+                            "doc_values": false
+                        },
+                        "name": {
+                            "type": "text",
+                            "analyzer": "standard",
+                            "search_analyzer": "standard",
+                            "fields": {
+                                "keyword": {
+                                    "type": "keyword"
+                                }
+                            },
+                            "index_options": "docs",
+                            "index": true,
+                            "norms": false,
+                            "fielddata": true
+                        },
+                        "image": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "url": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "telephone": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "disabilityAccess": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "mail": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "city": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "street": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "suite": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "region": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "postalCode": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": true,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "country": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "coordinates": {
+                            "type": "geo_point"
+                        }
+                    }
+                },
+                "occurrences": {
+                    "properties": {
+                        "entityId": {
+                            "type": "integer",
+                            "doc_values": false
+                        },
+                        "start": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "end": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "ticketPriceRange": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "room": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "status": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        }
+                    }
+                },
+                "dailyOccurrences": {
+                    "properties": {
+                        "entityId": {
+                            "type": "integer",
+                            "doc_values": false
+                        },
+                        "start": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "end": {
+                            "type": "date",
+                            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+                            "index": false,
+                            "doc_values": true
+                        },
+                        "ticketPriceRange": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "room": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        },
+                        "status": {
+                            "type": "keyword",
+                            "index_options": "docs",
+                            "index": false,
+                            "doc_values": false,
+                            "norms": false
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tests/resources/mappings/organizations.json
+++ b/tests/resources/mappings/organizations.json
@@ -1,0 +1,49 @@
+{
+    "dynamic": "strict",
+    "properties": {
+        "entityId": {
+            "type": "integer",
+            "doc_values": false
+        },
+        "name": {
+            "type": "text",
+            "analyzer": "standard",
+            "search_analyzer": "standard",
+            "fields": {
+                "keyword": {
+                    "type": "keyword"
+                }
+            },
+            "index_options": "docs",
+            "index": true,
+            "norms": false,
+            "fielddata": true
+        },
+        "email": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "url": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": false,
+            "doc_values": false,
+            "norms": false
+        },
+        "created": {
+            "type": "date",
+            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+            "index": false,
+            "doc_values": true
+        },
+        "updated": {
+            "type": "date",
+            "format": "yyyy-MM-dd'T'HH:mm:ssz",
+            "index": false,
+            "doc_values": true
+        }
+    }
+}

--- a/tests/resources/mappings/tags.json
+++ b/tests/resources/mappings/tags.json
@@ -1,0 +1,32 @@
+{
+    "dynamic": "strict",
+    "properties": {
+        "name": {
+            "type": "text",
+            "analyzer": "standard",
+            "search_analyzer": "standard",
+            "fields": {
+                "keyword": {
+                    "type": "keyword"
+                }
+            },
+            "index_options": "docs",
+            "index": true,
+            "norms": false,
+            "fielddata": true
+        },
+        "slug": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": true,
+            "norms": false
+        },
+        "vocabulary": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": true,
+            "doc_values": false,
+            "norms": false
+        }
+    }
+}

--- a/tests/resources/mappings/vocabularies.json
+++ b/tests/resources/mappings/vocabularies.json
@@ -1,0 +1,39 @@
+{
+    "dynamic": "strict",
+    "properties": {
+        "name": {
+            "type": "text",
+            "analyzer": "standard",
+            "search_analyzer": "standard",
+            "fields": {
+                "keyword": {
+                    "type": "keyword"
+                }
+            },
+            "index_options": "docs",
+            "index": true,
+            "norms": false,
+            "fielddata": true
+        },
+        "slug": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": true,
+            "doc_values": true,
+            "norms": false
+        },
+        "description": {
+            "type": "text",
+            "index_options": "docs",
+            "index": false,
+            "norms": false
+        },
+        "tags": {
+            "type": "keyword",
+            "index_options": "docs",
+            "index": true,
+            "doc_values": false,
+            "norms": false
+        }
+    }
+}


### PR DESCRIPTION
The test harness created Elasticsearch indexes with **no mappings**, so Elasticsearch **dynamic mapping** (analysed `text` + `.keyword` subfields) silently drove filter behaviour. Production indexes (created by `event-database-imports`) use **`dynamic: strict`** with explicit per-field types and no normalizer. As a result several filter tests were **green for semantics production does not have** — most starkly tag filtering: `?tags=itkdev` matched under dynamic mapping, but `tags` is an exact, case-sensitive `keyword` in production (fixtures store `"ITKDev"`).

## Changes

- **`tests/resources/mappings/*.json`** — production-parity mappings (`dynamic: strict`), hand-kept copies of the importer's `src/Model/Indexing/Mappings/*`, covering all 7 indexes.
- **`src/Fixtures/FixtureLoader.php`** — `createIndex()` applies the mapping for the index and **fails loudly if the mapping file is missing** (never silently creates a dynamic index). Injected `$mappingsDir` via `config/services.yaml`.
- **`Taskfile.yml`** — dropped `ignore_error: true` from the fixture targets (the `entityId` warning it masked is already gone), so fixture-load failures now surface.
- **Reconciled tag filter expectations** to keyword semantics — `EventsFilterTest`/`OccurrencesFilterTest`/`DailyOccurrencesFilterTest`: `ITKDev`→2, `itkdev`→0 (case-sensitive), `aros`→3, `for-boern`→1 (whole-value, not substring), `boern`→0. The two `@todo` blocks guessing at "contains-word" tag behaviour are deleted — this is their answer. **Only the tag cases needed changing**; every other filter/contract/pagination test was already production-accurate.
- **Automation** — the index-contract `Stop` hook now also watches `tests/resources/mappings/`; the `filter-provider-reviewer` brief checks the *mapped* field type (`keyword` = exact, `text` = tokenised).

## Verification

- All docs index cleanly under `dynamic: strict`; a doc with an unmapped field is rejected (`strict_dynamic_mapping_exception`, verified against a throwaway index).
- `task fixtures:load:test --yes` + `task api:test` → **166 tests, 447 assertions, 4 skipped** (the pre-existing `FilterErrorTest` skips). php-cs-fixer, PHPStan level 8, and prettier/markdownlint all clean.
- `CollectionContractTest`/`ItemContractTest` unchanged (raw `_source` passthrough — a control group proving the harness change altered query semantics only).

## Note

Tag matching is now pinned as **exact, case-sensitive** (production reality). If case-insensitive tag search is the desired product contract, that is a `lowercase` normalizer on the keyword mappings **in `event-database-imports`** (plus a reindex), not a change here.