### PR TITLE
ci: upload test coverage to Codecov

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -30,7 +30,7 @@ jobs:
           task --yes api:test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         with:
           files: ./coverage/unit.xml
           flags: unittests

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -27,7 +27,15 @@ jobs:
 
       - name: Run API tests
         run: |
-          task --yes api:test
+          task --yes api:test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage/unit.xml
+          flags: unittests
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   code-analysis-phpstan:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ phpstan.neon
 ###> claude-code ###
 /.claude/settings.local.json
 ###< claude-code ###
+
+# Coverage reports (generated in CI, uploaded to Codecov).
+/coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-37](https://github.com/itk-dev/event-database-api/pull/37)
+  Upload test coverage to Codecov in CI
 - [PR-33](https://github.com/itk-dev/event-database-api/pull/33)
   Mature the API test suite ahead of the API Platform upgrade (contract, filter, pagination and error tests)
 - [PR-32](https://github.com/itk-dev/event-database-api/pull/32)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -186,6 +186,13 @@ tasks:
         vars:
           COMPOSE_ARGS: exec phpfpm bin/phpunit
 
+  api:test:coverage:
+    desc: Run API tests with a Clover coverage report (coverage/unit.xml)
+    cmds:
+      - task: compose
+        vars:
+          COMPOSE_ARGS: exec --env XDEBUG_MODE=coverage phpfpm bin/phpunit --coverage-clover=coverage/unit.xml
+
   api:spec:export:
     desc: Export API spec
     cmds:


### PR DESCRIPTION
The README already links a Codecov badge, but CI never produced or uploaded a coverage report. Wire it up, mirroring the `event-database-imports` setup.

## Changes

- **`Taskfile.yml`** — new `api:test:coverage` target: runs PHPUnit with `XDEBUG_MODE=coverage` and `--coverage-clover=coverage/unit.xml` (the itkdev php8.4 image already ships Xdebug).
- **`.github/workflows/pr.yaml`** — the `api-test` job now runs `task api:test:coverage` and uploads via `codecov/codecov-action@v5` with `flags: unittests`, using the **org-level `CODECOV_TOKEN`** secret.
- **`.gitignore`** — ignore the generated `/coverage` directory.

## Verification

`task api:test:coverage` locally produces a valid Clover `coverage/unit.xml` and the suite still gates (164 tests, 4 skipped). YAML is prettier-clean. `coverage/` is untracked.

## Note

Coverage upload needs the org-level `CODECOV_TOKEN` to be exposed to this repo's Actions (same as event-database-imports). If the first run reports a missing token, that's an org/repo secret-visibility setting, not a workflow change.