### PR TITLE
ci: update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/api-spec.yml
+++ b/.github/workflows/api-spec.yml
@@ -12,12 +12,12 @@ jobs:
     name: Ensure committed API specification is up to date
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 
       # https://taskfile.dev/installation/#github-actions
-      - uses: go-task/setup-task@v1
+      - uses: go-task/setup-task@v2
 
       - run: |
           docker network create frontend
@@ -53,13 +53,13 @@ jobs:
     needs: [api-spec]
     steps:
       - name: Check out BASE rev
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.base_ref }}
           path: base
 
       - name: Check out HEAD rev
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           ref: ${{ github.head_ref }}
           path: head

--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -16,7 +16,7 @@ jobs:
       APP_ENV: prod
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Composer install
         run: |

--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           fetch-depth: 2
 

--- a/.github/workflows/composer.yaml
+++ b/.github/workflows/composer.yaml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |
@@ -55,7 +55,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/.github/workflows/markdown.yaml
+++ b/.github/workflows/markdown.yaml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/.github/workflows/php.yaml
+++ b/.github/workflows/php.yaml
@@ -48,7 +48,7 @@ jobs:
     name: PHP - Check Coding Standards
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -11,10 +11,10 @@ jobs:
     name: API test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # https://taskfile.dev/installation/#github-actions
-      - uses: go-task/setup-task@v1
+      - uses: go-task/setup-task@v2
 
       - name: Start docker compose setup and install site
         run: |
@@ -33,10 +33,10 @@ jobs:
     runs-on: ubuntu-latest
     name: PHPStan static analysis
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # https://taskfile.dev/installation/#github-actions
-      - uses: go-task/setup-task@v1
+      - uses: go-task/setup-task@v2
 
       - run: |
           docker network create frontend

--- a/.github/workflows/twig.yaml
+++ b/.github/workflows/twig.yaml
@@ -40,7 +40,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/.github/workflows/yaml.yaml
+++ b/.github/workflows/yaml.yaml
@@ -31,7 +31,7 @@ jobs:
   yaml-lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Create docker network
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-39](https://github.com/itk-dev/event-database-api/pull/39)
+  Update GitHub Actions to latest: actions/checkout v7 and go-task/setup-task v2
 - [PR-36](https://github.com/itk-dev/event-database-api/pull/36)
   Add unit tests pinning the Elasticsearch filters' query DSL and parameter descriptors
 - [PR-35](https://github.com/itk-dev/event-database-api/pull/35)


### PR DESCRIPTION
Update the GitHub Actions used across workflows to their latest versions.

## Changes

- **`actions/checkout` v5 → v7** across all 9 workflows.
- **`go-task/setup-task` v1 → v2** (Node 24 runtime; non-breaking for our bare usage) in the repo-owned workflows (`pr.yaml`, `api-spec.yml`).
- `codecov/codecov-action` is already on v7 (PR #37); `openapi-diff` is pinned to `:latest`.

## Notes

- Staying on **`go-task/setup-task`** (the itkdev-ecosystem choice), not `arduino/setup-task`.
- The itkdev-**templated** workflows (`composer`, `php`, `twig`, `markdown`, `yaml`, `changelog`) are bumped to checkout v7 here, which is **ahead of the current `devops_itkdev-docker` template (v6)** — the upstream bump to v7 is pending, after which these stay in sync.

prettier + markdownlint clean.