### PR TITLE
ci: run the Code Review workflow via docker compose (drop Task)

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -13,21 +13,29 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # https://taskfile.dev/installation/#github-actions
-      - uses: go-task/setup-task@v1
+      - name: Cache vendor
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: vendor-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: vendor-php8.4-
 
       - name: Start docker compose setup and install site
         run: |
           docker network create frontend
-          task --yes site:update
+          docker compose pull --quiet
+          docker compose up --detach --wait
+          docker compose exec -T phpfpm composer install --no-interaction
 
       - name: Load test fixtures
         run: |
-          task --yes fixtures:load:test
+          for index in events organizations occurrences daily_occurrences tags vocabularies locations; do
+            docker compose exec -T phpfpm bin/console app:fixtures:load "$index" --url="file:///app/tests/resources/$index.json"
+          done
 
-      - name: Run API tests
+      - name: Run API tests with coverage
         run: |
-          task --yes api:test:coverage
+          docker compose exec -T -e XDEBUG_MODE=coverage phpfpm bin/phpunit --coverage-clover=coverage/unit.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7
@@ -43,13 +51,20 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # https://taskfile.dev/installation/#github-actions
-      - uses: go-task/setup-task@v1
+      - name: Cache vendor
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: vendor-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: vendor-php8.4-
 
-      - run: |
+      - name: Start docker compose setup and install site
+        run: |
           docker network create frontend
-          task --yes site:update
+          docker compose pull --quiet
+          docker compose up --detach --wait
+          docker compose exec -T phpfpm composer install --no-interaction
 
       - name: Run code analysis
         run: |
-          task --yes code-analysis:phpstan
+          docker compose exec -T phpfpm vendor/bin/phpstan analyse --no-progress

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-41](https://github.com/itk-dev/event-database-api/pull/41)
+  Run the Code Review workflow via docker compose directly (drop Task) with vendor caching and image pre-pull
 - [PR-37](https://github.com/itk-dev/event-database-api/pull/37)
   Upload test coverage to Codecov in CI
 - [PR-36](https://github.com/itk-dev/event-database-api/pull/36)


### PR DESCRIPTION
Standardise `pr.yaml` on `docker compose` directly instead of Task, and harden against composer's dist-download rate limit — adapted from [event-database-imports #98](https://github.com/itk-dev/event-database-imports/pull/98) (itself from os2display).

## Changes (`pr.yaml`, both jobs)

- **Vendor cache** — `actions/cache@v5` on `vendor/`, keyed on `composer.lock` with a `vendor-php8.4-` restore-key. On a hit `composer install` does no dist downloads (no HTTP 429); on a miss the restore-key pre-populates most of `vendor/`.
- **Image pre-pull** — `docker compose pull --quiet` up front.
- **Task → docker compose** — dropped `go-task/setup-task`; `task site:update` → `docker compose up --detach --wait` + `composer install`; `task fixtures:load:test` → an inline index loop; `task api:test:coverage` / `task code-analysis:phpstan` → direct `docker compose exec` calls (coverage still via `XDEBUG_MODE=coverage … --coverage-clover`).

The Taskfile targets stay for local development; only CI stops calling them.

## Verification

Ran the exact inlined commands locally: fixtures load for all 7 indexes, `phpunit --coverage-clover` → **203 tests / 496 assertions** + Clover report, phpstan level 8 clean, prettier clean.

## Note
Kept `actions/checkout@v5` (version bumps are PR #39's scope) — expect a trivial reconcile against #39 on merge. `api-spec.yml` still uses Task (PR #40); converting it can follow the same pattern if wanted.