### PR TITLE
Assert filter identities, sort order, and pagination edges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-43](https://github.com/itk-dev/event-database-api/pull/43)
+  Assert filter identities (not counts), sort order, and pagination edge cases
 - [PR-41](https://github.com/itk-dev/event-database-api/pull/41)
   Run the Code Review workflow via docker compose directly (drop Task) with vendor caching and image pre-pull
 - [PR-40](https://github.com/itk-dev/event-database-api/pull/40)

--- a/tests/ApiPlatform/AbstractApiTestCase.php
+++ b/tests/ApiPlatform/AbstractApiTestCase.php
@@ -41,4 +41,34 @@ abstract class AbstractApiTestCase extends ApiTestCase
     {
         return (new \DateTimeImmutable($datetime))->format(\DateTimeImmutable::ATOM);
     }
+
+    /**
+     * Assert a collection response contains exactly the expected member identities.
+     *
+     * Reads $field from each `hydra:member` — `entityId` for most resources,
+     * `slug` for Tag/Vocabulary. The comparison is order-independent by default;
+     * pass $ordered to also assert the sequence (used by the sort contract).
+     *
+     * @param array<int|string>                                $expected
+     */
+    protected function assertMemberIds(array $expected, ResponseInterface $response, string $field = 'entityId', bool $ordered = false, string $message = ''): void
+    {
+        $data = $response->toArray();
+        self::assertArrayHasKey('hydra:member', $data, $message);
+
+        $actual = array_map(
+            static fn (array $member) => $member[$field] ?? null,
+            $data['hydra:member']
+        );
+
+        if ($ordered) {
+            self::assertSame($expected, $actual, $message);
+
+            return;
+        }
+
+        sort($expected);
+        sort($actual);
+        self::assertSame($expected, $actual, $message);
+    }
 }

--- a/tests/ApiPlatform/DailyOccurrencesFilterTest.php
+++ b/tests/ApiPlatform/DailyOccurrencesFilterTest.php
@@ -5,63 +5,48 @@ namespace App\Tests\ApiPlatform;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * Test that filtering daily_occurrences work as expected.
+ * Test that filtering daily_occurrences works as expected.
+ *
+ * Assertions pin the exact set of matching `entityId`s. Fixture ids mirror the
+ * occurrences index: 10/11 belong to event 8, 12 to event 7.
  */
 class DailyOccurrencesFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/daily_occurrences';
 
     #[DataProvider('getDailyOccurrencesProvider')]
-    public function testGetDailyOccurrences(array $query, int $expectedCount, ?string $message = null): void
+    public function testGetDailyOccurrences(array $query, array $expectedIds, ?string $message = null): void
     {
-        $message ??= '';
-
         $response = $this->get($query);
 
-        $data = $response->toArray();
-        $this->assertArrayHasKey('hydra:member', $data, $message);
-        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+        $this->assertMemberIds($expectedIds, $response, 'entityId', message: $message ?? '');
     }
 
     public static function getDailyOccurrencesProvider(): iterable
     {
-        // Unfiltered.
-        yield [[], 3];
+        yield 'unfiltered' => [[], [10, 11, 12]];
 
         // BooleanFilter on event.publicAccess (DailyOccurrence-specific).
-        yield [
+        yield 'event publicAccess=true' => [
             ['event.publicAccess' => 'true'],
-            3,
-            'All fixture events have publicAccess=true',
+            [10, 11, 12],
+            'All daily occurrences belong to public events',
         ];
 
         // DateRangeFilter on start.
-        yield [
+        yield 'start in December 2024' => [
             ['start[between]' => static::formatDateTime('2024-12-01').'..'.static::formatDateTime('2024-12-31')],
-            2,
+            [10, 12],
         ];
 
         // MatchFilter on event.title (token-based — see OccurrencesFilterTest comment).
-        yield [
-            ['event.title' => 'ITKDev'],
-            3,
-        ];
+        yield 'event title token ITKDev' => [['event.title' => 'ITKDev'], [10, 11, 12]];
 
         // IdFilter on event.organizer.entityId.
-        yield [
-            ['event.organizer.entityId' => 9],
-            3,
-        ];
+        yield 'event organizer 9' => [['event.organizer.entityId' => 9], [10, 11, 12]];
 
         // TagFilter on event.tags — keyword field, exact/case-sensitive match.
-        yield [
-            ['event.tags' => 'ITKDev'],
-            1,
-        ];
-
-        yield [
-            ['event.tags' => 'unknown-tag'],
-            0,
-        ];
+        yield 'event tag ITKDev' => [['event.tags' => 'ITKDev'], [12]];
+        yield 'event tag unknown' => [['event.tags' => 'unknown-tag'], []];
     }
 }

--- a/tests/ApiPlatform/EventsFilterTest.php
+++ b/tests/ApiPlatform/EventsFilterTest.php
@@ -5,137 +5,97 @@ namespace App\Tests\ApiPlatform;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * Test that filtering events work as expected.
+ * Test that filtering events works as expected.
+ *
+ * Assertions pin the exact set of matching event `entityId`s (not just counts),
+ * so a filter regression that returns the wrong records — not merely the wrong
+ * number of them — is caught. Fixture ids: 7, 8, 9 (see tests/resources/events.json).
  */
 class EventsFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/events';
 
     #[DataProvider('getEventsProvider')]
-    public function testGetEvents(array $query, int $expectedCount, ?string $message = null): void
+    public function testGetEvents(array $query, array $expectedIds, ?string $message = null): void
     {
-        $message ??= '';
-
         $response = $this->get($query);
 
-        $data = $response->toArray();
-        $this->assertArrayHasKey('hydra:member', $data, $message);
-        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+        $this->assertMemberIds($expectedIds, $response, 'entityId', message: $message ?? '');
     }
 
     public static function getEventsProvider(): iterable
     {
-        yield [
-            [],
-            3,
-        ];
+        yield 'unfiltered' => [[], [7, 8, 9]];
 
-        // Test BooleanFilter.
-        yield [
-            ['publicAccess' => 'true'],
-            2,
-        ];
+        // BooleanFilter on publicAccess (7 and 9 are public, 8 is not).
+        yield 'publicAccess=true' => [['publicAccess' => 'true'], [7, 9]];
+        yield 'publicAccess=false' => [['publicAccess' => 'false'], [8]];
 
-        yield [
-            ['publicAccess' => 'false'],
-            1,
-        ];
-
-        // Test DateRangeFilter on occurrences.start.
-        yield [
+        // DateRangeFilter on occurrences.start.
+        yield 'occurrences in 21st century' => [
             ['occurrences.start[between]' => static::formatDateTime('2001-01-01').'..'.static::formatDateTime('2100-01-01')],
-            3,
-            'Events in 21st century',
+            [7, 8, 9],
+            'Every fixture event has an occurrence in the 21st century',
         ];
-
-        yield [
+        yield 'occurrences in 2026' => [
             ['occurrences.start[between]' => static::formatDateTime('2026-01-01').'..'.static::formatDateTime('2026-12-31')],
-            1,
-            'Events in 2026',
+            [9],
+            'Only event 9 has an occurrence in 2026',
         ];
 
-        // Test DateRangeFilter on updated (default operator: gte).
-        yield [
+        // DateRangeFilter on updated (default operator: gte).
+        yield 'updated on or after 2024' => [
             ['updated' => static::formatDateTime('2024-01-01')],
-            3,
-            'Events updated on or after 2024-01-01',
+            [7, 8, 9],
+            'All events were updated on or after 2024-01-01',
         ];
-
-        yield [
+        yield 'updated after 2100' => [
             ['updated[gte]' => static::formatDateTime('2100-01-01')],
-            0,
+            [],
             'No events updated after 2100',
         ];
 
-        // Test IdFilter.
-        yield [
-            ['organizer.entityId' => 9],
-            2,
+        // F7: occurrences is a plain object (NOT `nested`) in production, so range
+        // clauses on occurrences.start and occurrences.end are evaluated
+        // independently across the flattened arrays. Event 8 has occurrences
+        // (start 2024-12-07 / end 2024-12-07) and (start 2024-11-08 / end 2024-11-08):
+        // NO single occurrence has start >= 2024-12-01 AND end <= 2024-11-30, yet the
+        // event still matches. Pinning this makes a future switch to `nested` mapping
+        // a conscious, BC-visible decision.
+        yield 'F7: start/end satisfied by different occurrences' => [
+            [
+                'occurrences.start[gte]' => static::formatDateTime('2024-12-01'),
+                'occurrences.end[lte]' => static::formatDateTime('2024-11-30'),
+            ],
+            [8],
+            'Non-nested occurrences: event 8 matches although no single occurrence satisfies both bounds',
         ];
 
-        yield [
-            ['organizer.entityId' => 11],
-            1,
-        ];
+        // IdFilter on organizer.entityId (7 and 8 belong to organizer 9; 9 to organizer 11).
+        yield 'organizer 9' => [['organizer.entityId' => 9], [7, 8]];
+        yield 'organizer 11' => [['organizer.entityId' => 11], [9]];
 
-        // Test MatchFilter.
-        yield [
-            ['location.name' => 'somewhere'],
-            1,
-            'An event somewhere',
-        ];
+        // MatchFilter on location.name (`name` is a `text` field → token match).
+        yield 'location somewhere' => [['location.name' => 'somewhere'], [9], 'Event 9 is at "Somewhere"'];
+        yield 'location another place' => [['location.name' => 'Another place'], []];
 
-        yield [
-            ['location.name' => 'Another place'],
-            0,
-        ];
-
-        // Test TagFilter. In production `tags` is a keyword field (see event-database-imports
+        // TagFilter. In production `tags` is a keyword field (see event-database-imports
         // Mappings/Event) — matching is exact, case-sensitive and whole-value (no tokenisation).
-        yield [
-            ['tags' => 'ITKDev'],
-            2,
-            'Events tagged with "ITKDev" (exact keyword match)',
-        ];
-
-        yield [
-            ['tags' => 'itkdev'],
-            0,
-            'Tag matching is case-sensitive: "itkdev" does not match "ITKDev"',
-        ];
-
-        yield [
-            ['tags' => 'aros'],
-            3,
-            'All fixture events are tagged "aros"',
-        ];
-
-        yield [
-            ['tags' => 'for-boern'],
-            1,
-            'A hyphenated tag matches as a whole value, not by token',
-        ];
-
-        yield [
-            ['tags' => 'boern'],
-            0,
-            'No substring/token match on a keyword field',
-        ];
-
-        yield [
-            ['tags' => 'itkdevelopment'],
-            0,
-            'Events tagged with "itkdevelopment"',
-        ];
+        yield 'tag ITKDev' => [['tags' => 'ITKDev'], [7, 9], 'Events tagged "ITKDev" (exact keyword match)'];
+        yield 'tag itkdev (wrong case)' => [['tags' => 'itkdev'], [], 'Tag matching is case-sensitive'];
+        yield 'tag aros' => [['tags' => 'aros'], [7, 8, 9], 'All fixture events are tagged "aros"'];
+        yield 'tag for-boern' => [['tags' => 'for-boern'], [9], 'A hyphenated tag matches as a whole value'];
+        yield 'tag boern (substring)' => [['tags' => 'boern'], [], 'No substring/token match on a keyword field'];
+        yield 'tag itkdevelopment' => [['tags' => 'itkdevelopment'], []];
 
         // Combined filters.
-        yield [
+        yield 'occurrences in 2026 AND tagged aros' => [
             [
                 'occurrences.start[between]' => static::formatDateTime('2026-01-01').'..'.static::formatDateTime('2026-12-31'),
                 'tags' => 'aros',
             ],
-            1,
-            'Events in 2026 also tagged "aros"',
+            [9],
+            'Event 9 is the only 2026 event also tagged "aros"',
         ];
     }
 }

--- a/tests/ApiPlatform/LocationsFilterTest.php
+++ b/tests/ApiPlatform/LocationsFilterTest.php
@@ -5,36 +5,34 @@ namespace App\Tests\ApiPlatform;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * Test that filtering locations work as expected.
+ * Test that filtering locations works as expected.
+ *
+ * Assertions pin the exact set of matching `entityId`s. Fixture ids: 4 (ITK
+ * Development, postal 8000), 5 (Somewhere). See tests/resources/locations.json.
  */
 class LocationsFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/locations';
 
     #[DataProvider('getLocationsProvider')]
-    public function testGetLocations(array $query, int $expectedCount, ?string $message = null): void
+    public function testGetLocations(array $query, array $expectedIds, ?string $message = null): void
     {
-        $message ??= '';
-
         $response = $this->get($query);
 
-        $data = $response->toArray();
-        $this->assertArrayHasKey('hydra:member', $data, $message);
-        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+        $this->assertMemberIds($expectedIds, $response, 'entityId', message: $message ?? '');
     }
 
     public static function getLocationsProvider(): iterable
     {
-        // Unfiltered.
-        yield [[], 2];
+        yield 'unfiltered' => [[], [4, 5]];
 
-        // MatchFilter on name.
-        yield [['name' => 'ITK Development'], 1, 'Location named "ITK Development"'];
-        yield [['name' => 'Somewhere'], 1, 'Location named "Somewhere"'];
-        yield [['name' => 'nonexistent'], 0];
+        // MatchFilter on name (`name` is a `text` field → token match).
+        yield 'name ITK Development' => [['name' => 'ITK Development'], [4], 'Location 4 is "ITK Development"'];
+        yield 'name Somewhere' => [['name' => 'Somewhere'], [5], 'Location 5 is "Somewhere"'];
+        yield 'name nonexistent' => [['name' => 'nonexistent'], []];
 
-        // MatchFilter on postalCode.
-        yield [['postalCode' => '8000'], 1, 'Location with postal code 8000'];
-        yield [['postalCode' => '9999'], 0];
+        // MatchFilter on postalCode (`postalCode` is a `keyword` field → exact match).
+        yield 'postalCode 8000' => [['postalCode' => '8000'], [4], 'Location 4 has postal code 8000'];
+        yield 'postalCode 9999' => [['postalCode' => '9999'], []];
     }
 }

--- a/tests/ApiPlatform/OccurrencesFilterTest.php
+++ b/tests/ApiPlatform/OccurrencesFilterTest.php
@@ -5,106 +5,69 @@ namespace App\Tests\ApiPlatform;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * Test that filtering occurrences work as expected.
+ * Test that filtering occurrences works as expected.
+ *
+ * Assertions pin the exact set of matching occurrence `entityId`s. Fixture ids:
+ * 10 (start 2024-12-07, event 8), 11 (start 2024-11-08, event 8),
+ * 12 (start 2024-12-08, event 7). See tests/resources/occurrences.json.
  */
 class OccurrencesFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/occurrences';
 
     #[DataProvider('getOccurrencesProvider')]
-    public function testGetOccurrences(array $query, int $expectedCount, ?string $message = null): void
+    public function testGetOccurrences(array $query, array $expectedIds, ?string $message = null): void
     {
-        $message ??= '';
-
         $response = $this->get($query);
 
-        $data = $response->toArray();
-        $this->assertArrayHasKey('hydra:member', $data, $message);
-        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+        $this->assertMemberIds($expectedIds, $response, 'entityId', message: $message ?? '');
     }
 
     public static function getOccurrencesProvider(): iterable
     {
-        // Unfiltered.
-        yield [[], 3];
+        yield 'unfiltered' => [[], [10, 11, 12]];
 
         // DateRangeFilter on start.
-        yield [
+        yield 'start in December 2024' => [
             ['start[between]' => static::formatDateTime('2024-12-01').'..'.static::formatDateTime('2024-12-31')],
-            2,
-            'Occurrences starting in December 2024',
+            [10, 12],
+            'Occurrences 10 and 12 start in December 2024',
         ];
-
-        yield [
+        yield 'start in November 2024' => [
             ['start[between]' => static::formatDateTime('2024-11-01').'..'.static::formatDateTime('2024-11-30')],
-            1,
-            'Occurrences starting in November 2024',
+            [11],
+            'Only occurrence 11 starts in November 2024',
         ];
 
         // DateRangeFilter on end.
-        yield [
+        yield 'end around 2024-12-08' => [
             ['end[between]' => static::formatDateTime('2024-12-07').'..'.static::formatDateTime('2024-12-09')],
-            2,
-            'Occurrences ending around 2024-12-08',
+            [10, 12],
+            'Occurrences 10 and 12 end within 2024-12-07..2024-12-09',
         ];
 
         // MatchFilter on event.title. `title` is a `text` field in production (see
         // event-database-imports Mappings/Event), so ES tokenises it and this is a word
-        // match — all three fixture events share the tokens "ITKDev/test/event".
-        // To narrow we'd need a token unique to a single record.
-        yield [
+        // match — all three fixture events share the token "ITKDev".
+        yield 'event title token ITKDev' => [
             ['event.title' => 'ITKDev'],
-            3,
+            [10, 11, 12],
             'All fixture events have "ITKDev" in the title',
         ];
+        yield 'event title absent token' => [['event.title' => 'totallyuniqueword'], []];
 
-        yield [
-            ['event.title' => 'totallyuniqueword'],
-            0,
-            'Token absent from all titles returns no occurrences',
-        ];
+        // MatchFilter on event.organizer.name / event.location.name (all events share these).
+        yield 'event organizer name ITKDev' => [['event.organizer.name' => 'ITKDev'], [10, 11, 12]];
+        yield 'event location name' => [['event.location.name' => 'ITK Development'], [10, 11, 12]];
 
-        // MatchFilter on event.organizer.name.
-        yield [
-            ['event.organizer.name' => 'ITKDev'],
-            3,
-            'Occurrences organized by ITKDev',
-        ];
+        // IdFilter on event.organizer.entityId / event.location.entityId.
+        yield 'event organizer 9' => [['event.organizer.entityId' => 9], [10, 11, 12]];
+        yield 'event organizer 99' => [['event.organizer.entityId' => 99], []];
+        yield 'event location 4' => [['event.location.entityId' => 4], [10, 11, 12]];
 
-        // MatchFilter on event.location.name.
-        yield [
-            ['event.location.name' => 'ITK Development'],
-            3,
-            'Occurrences at ITK Development',
-        ];
-
-        // IdFilter on event.organizer.entityId.
-        yield [
-            ['event.organizer.entityId' => 9],
-            3,
-        ];
-
-        yield [
-            ['event.organizer.entityId' => 99],
-            0,
-        ];
-
-        // IdFilter on event.location.entityId.
-        yield [
-            ['event.location.entityId' => 4],
-            3,
-        ];
-
-        // TagFilter on event.tags — keyword field, exact/case-sensitive match.
-        yield [
-            ['event.tags' => 'ITKDev'],
-            1,
-            'Occurrences for events tagged "ITKDev"',
-        ];
-
-        yield [
-            ['event.tags' => 'unknown-tag'],
-            0,
-        ];
+        // TagFilter on event.tags — keyword field, exact/case-sensitive match. Only
+        // occurrence 12 belongs to event 7, which carries the "ITKDev" tag.
+        yield 'event tag ITKDev' => [['event.tags' => 'ITKDev'], [12], 'Occurrence 12 belongs to the ITKDev-tagged event'];
+        yield 'event tag unknown' => [['event.tags' => 'unknown-tag'], []];
     }
 }

--- a/tests/ApiPlatform/OrganizationsFilterTest.php
+++ b/tests/ApiPlatform/OrganizationsFilterTest.php
@@ -5,33 +5,31 @@ namespace App\Tests\ApiPlatform;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * Test that filtering organizations work as expected.
+ * Test that filtering organizations works as expected.
+ *
+ * Assertions pin the exact set of matching `entityId`s. Fixture ids: 9 (ITKDev),
+ * 10 (Aakb), 11 (Dokk1). See tests/resources/organizations.json.
  */
 class OrganizationsFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/organizations';
 
     #[DataProvider('getOrganizationsProvider')]
-    public function testGetOrganizations(array $query, int $expectedCount, ?string $message = null): void
+    public function testGetOrganizations(array $query, array $expectedIds, ?string $message = null): void
     {
-        $message ??= '';
-
         $response = $this->get($query);
 
-        $data = $response->toArray();
-        $this->assertArrayHasKey('hydra:member', $data, $message);
-        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+        $this->assertMemberIds($expectedIds, $response, 'entityId', message: $message ?? '');
     }
 
     public static function getOrganizationsProvider(): iterable
     {
-        // Unfiltered.
-        yield [[], 3];
+        yield 'unfiltered' => [[], [9, 10, 11]];
 
-        // MatchFilter on name.
-        yield [['name' => 'ITKDev'], 1, 'Organization named "ITKDev"'];
-        yield [['name' => 'Dokk1'], 1];
-        yield [['name' => 'Aakb'], 1];
-        yield [['name' => 'nonexistent'], 0];
+        // MatchFilter on name (`name` is a `text` field → token match).
+        yield 'name ITKDev' => [['name' => 'ITKDev'], [9], 'Organization 9 is "ITKDev"'];
+        yield 'name Dokk1' => [['name' => 'Dokk1'], [11]];
+        yield 'name Aakb' => [['name' => 'Aakb'], [10]];
+        yield 'name nonexistent' => [['name' => 'nonexistent'], []];
     }
 }

--- a/tests/ApiPlatform/PaginationTest.php
+++ b/tests/ApiPlatform/PaginationTest.php
@@ -69,6 +69,40 @@ class PaginationTest extends AbstractApiTestCase
         $this->assertArrayHasKey('hydra:previous', $data['hydra:view'], 'Page 3 of 3 should expose hydra:previous');
     }
 
+    public function testOutOfRangePageReturnsEmptyMemberButFullTotal(): void
+    {
+        // 3 events, itemsPerPage=1 → page 99 is past the end. The slice is empty
+        // but hydra:totalItems still reports the full unpaginated count.
+        $data = $this->get(['itemsPerPage' => 1, 'page' => 99], '/api/v2/events')->toArray();
+
+        $this->assertSame([], $data['hydra:member'], 'An out-of-range page must return an empty member list');
+        $this->assertSame(3, $data['hydra:totalItems'], 'totalItems must ignore pagination');
+    }
+
+    public function testTotalItemsReflectsActiveFilter(): void
+    {
+        // hydra:totalItems must count the filtered result set, not the whole index.
+        $data = $this->get(['publicAccess' => 'true'], '/api/v2/events')->toArray();
+
+        $this->assertSame(2, $data['hydra:totalItems'], 'totalItems must reflect the publicAccess=true filter');
+        $this->assertCount(2, $data['hydra:member']);
+    }
+
+    public function testPagingThroughSingleItemPagesCoversTheFullSet(): void
+    {
+        // Walking every page at itemsPerPage=1 must yield each event exactly once —
+        // no gaps, no duplicates across page boundaries.
+        $seen = [];
+        for ($page = 1; $page <= 3; ++$page) {
+            $data = $this->get(['itemsPerPage' => 1, 'page' => $page], '/api/v2/events')->toArray();
+            $this->assertCount(1, $data['hydra:member'], 'Page '.$page.' should hold exactly one event');
+            $seen[] = $data['hydra:member'][0]['entityId'];
+        }
+
+        sort($seen);
+        $this->assertSame([7, 8, 9], $seen, 'Pages 1∪2∪3 must equal the full event set with no duplicates');
+    }
+
     public static function resourceProvider(): iterable
     {
         // [path, fixture count, paginationMaximumItemsPerPage]

--- a/tests/ApiPlatform/SortTest.php
+++ b/tests/ApiPlatform/SortTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace App\Tests\ApiPlatform;
+
+/**
+ * Pin the default result ordering — the contract of
+ * ElasticSearchIndex::getSort(), which is otherwise asserted nowhere. There is
+ * no client-facing sort parameter yet, so this order IS the contract.
+ *
+ * Covers all three non-default branches:
+ *  - Events               → _score, then title.keyword ascending
+ *  - Occurrences / Daily  → start ascending
+ *  - Tags/Vocab/Loc/Org   → _score, then name.keyword ascending
+ */
+class SortTest extends AbstractApiTestCase
+{
+    protected static string $requestPath = '/api/v2/events';
+
+    public function testEventsAreSortedByTitleAscending(): void
+    {
+        $data = $this->get([], '/api/v2/events')->toArray();
+        $titles = array_column($data['hydra:member'], 'title');
+
+        $sorted = $titles;
+        sort($sorted, SORT_STRING);
+
+        self::assertSame($sorted, $titles, 'Events must be ordered by title.keyword ascending');
+    }
+
+    public function testOccurrencesAreSortedByStartAscending(): void
+    {
+        $response = $this->get([], '/api/v2/occurrences');
+
+        // Fixture starts: 11 = 2024-11-08, 10 = 2024-12-07, 12 = 2024-12-08.
+        $this->assertMemberIds([11, 10, 12], $response, 'entityId', ordered: true, message: 'Occurrences must be ordered by start ascending');
+
+        $starts = array_column($response->toArray()['hydra:member'], 'start');
+        $sorted = $starts;
+        sort($sorted, SORT_STRING);
+        self::assertSame($sorted, $starts, 'start values must be ascending');
+    }
+
+    public function testDailyOccurrencesAreSortedByStartAscending(): void
+    {
+        $response = $this->get([], '/api/v2/daily_occurrences');
+
+        $this->assertMemberIds([11, 10, 12], $response, 'entityId', ordered: true, message: 'Daily occurrences must be ordered by start ascending');
+    }
+
+    public function testOrganizationsAreSortedByNameAscending(): void
+    {
+        $response = $this->get([], '/api/v2/organizations');
+
+        // name.keyword ascending (byte order): Aakb (10), Dokk1 (11), ITKDev (9).
+        $this->assertMemberIds([10, 11, 9], $response, 'entityId', ordered: true, message: 'Organizations must be ordered by name.keyword ascending');
+    }
+}

--- a/tests/ApiPlatform/TagsFilterTest.php
+++ b/tests/ApiPlatform/TagsFilterTest.php
@@ -5,36 +5,39 @@ namespace App\Tests\ApiPlatform;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * Test that filtering tags work as expected.
+ * Test that filtering tags works as expected.
+ *
+ * Tag is a true API Platform resource identified by `slug`, so assertions pin
+ * the exact set of matching slugs. Fixture slugs: aros, theoceanraceaarhus,
+ * koncert, for-boern, itkdev (see tests/resources/tags.json).
  */
 class TagsFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/tags';
 
     #[DataProvider('getTagsProvider')]
-    public function testGetTags(array $query, int $expectedCount, ?string $message = null): void
+    public function testGetTags(array $query, array $expectedSlugs, ?string $message = null): void
     {
-        $message ??= '';
-
         $response = $this->get($query);
 
-        $data = $response->toArray();
-        $this->assertArrayHasKey('hydra:member', $data, $message);
-        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+        $this->assertMemberIds($expectedSlugs, $response, 'slug', message: $message ?? '');
     }
 
     public static function getTagsProvider(): iterable
     {
-        // Unfiltered.
-        yield [[], 5];
+        yield 'unfiltered' => [[], ['aros', 'theoceanraceaarhus', 'koncert', 'for-boern', 'itkdev']];
 
-        // MatchFilter on name.
-        yield [['name' => 'aros'], 1, 'Tag named "aros"'];
-        yield [['name' => 'Koncert'], 1];
-        yield [['name' => 'nonexistent'], 0];
+        // MatchFilter on name (`name` is a `text` field → token match); slug is the identity.
+        yield 'name aros' => [['name' => 'aros'], ['aros'], 'Tag named "aros"'];
+        yield 'name Koncert' => [['name' => 'Koncert'], ['koncert'], 'Tag "Koncert" has slug "koncert"'];
+        yield 'name nonexistent' => [['name' => 'nonexistent'], []];
 
         // MatchFilter on vocabulary.
-        yield [['vocabulary' => 'aarhusguiden'], 5, 'All fixture tags belong to the aarhusguiden vocabulary'];
-        yield [['vocabulary' => 'feeds'], 0];
+        yield 'vocabulary aarhusguiden' => [
+            ['vocabulary' => 'aarhusguiden'],
+            ['aros', 'theoceanraceaarhus', 'koncert', 'for-boern', 'itkdev'],
+            'All fixture tags belong to the aarhusguiden vocabulary',
+        ];
+        yield 'vocabulary feeds' => [['vocabulary' => 'feeds'], []];
     }
 }

--- a/tests/ApiPlatform/VocabulariesFilterTest.php
+++ b/tests/ApiPlatform/VocabulariesFilterTest.php
@@ -5,36 +5,35 @@ namespace App\Tests\ApiPlatform;
 use PHPUnit\Framework\Attributes\DataProvider;
 
 /**
- * Test that filtering vocabularies work as expected.
+ * Test that filtering vocabularies works as expected.
+ *
+ * Vocabulary is a true API Platform resource identified by `slug`, so assertions
+ * pin the exact set of matching slugs. Fixture slugs: aarhusguiden, feeds
+ * (see tests/resources/vocabularies.json).
  */
 class VocabulariesFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/vocabularies';
 
     #[DataProvider('getVocabulariesProvider')]
-    public function testGetVocabularies(array $query, int $expectedCount, ?string $message = null): void
+    public function testGetVocabularies(array $query, array $expectedSlugs, ?string $message = null): void
     {
-        $message ??= '';
-
         $response = $this->get($query);
 
-        $data = $response->toArray();
-        $this->assertArrayHasKey('hydra:member', $data, $message);
-        $this->assertCount($expectedCount, $data['hydra:member'], $message);
+        $this->assertMemberIds($expectedSlugs, $response, 'slug', message: $message ?? '');
     }
 
     public static function getVocabulariesProvider(): iterable
     {
-        // Unfiltered.
-        yield [[], 2];
+        yield 'unfiltered' => [[], ['aarhusguiden', 'feeds']];
 
-        // MatchFilter on name.
-        yield [['name' => 'aarhusguiden'], 1];
-        yield [['name' => 'feeds'], 1];
-        yield [['name' => 'nonexistent'], 0];
+        // MatchFilter on name (`name` is a `text` field → token match); slug is the identity.
+        yield 'name aarhusguiden' => [['name' => 'aarhusguiden'], ['aarhusguiden']];
+        yield 'name feeds' => [['name' => 'feeds'], ['feeds']];
+        yield 'name nonexistent' => [['name' => 'nonexistent'], []];
 
-        // MatchFilter on tags.
-        yield [['tags' => 'aros'], 1, 'aarhusguiden vocabulary contains the "aros" tag'];
-        yield [['tags' => 'unknown-tag'], 0];
+        // MatchFilter on tags — only aarhusguiden contains the "aros" tag.
+        yield 'tags aros' => [['tags' => 'aros'], ['aarhusguiden'], 'aarhusguiden vocabulary contains the "aros" tag'];
+        yield 'tags unknown' => [['tags' => 'unknown-tag'], []];
     }
 }


### PR DESCRIPTION
Sharpens the behavioural test suite from counts to identities ahead of the API Platform upgrade, so a filter regression that returns the *wrong records* — not just the wrong number of them — is caught.

## Changes

- Add `AbstractApiTestCase::assertMemberIds()` — asserts the exact set of member identities (`entityId`, or `slug` for Tag/Vocabulary), order-independent by default.
- Convert all seven `*FilterTest` suites from `assertCount` to `assertMemberIds`, with named datasets and the reasoning for each expected id set.
- Add `SortTest` pinning `ElasticSearchIndex::getSort()` across all three branches: events (`title.keyword` asc), occurrence endpoints (`start` asc), organizations (`name.keyword` asc) — a contract asserted nowhere before.
- Add pagination-edge cases to `PaginationTest`: out-of-range page → empty member list but full `hydra:totalItems`; `totalItems` reflects an active filter; walking single-item pages covers the full set with no gaps or duplicates.
- Pin the non-nested `occurrences` semantic (F7): event 8 matches `occurrences.start[gte]` and `occurrences.end[lte]` bounds satisfied by *different* occurrences, because the field is a plain object, not `nested`.

## Why

The suite that guards the upcoming API Platform upgrade was count-based, so a filter could return a different-but-same-sized result set undetected. Identity assertions close that gap, and `SortTest` locks the default ordering (there is no client sort parameter yet, so the current order is the contract). Tests only — no production code changes.