### PR TITLE
Upgrade api-platform/core 4.1 → 4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-46](https://github.com/itk-dev/event-database-api/pull/46)
+  Upgrade api-platform/core 4.1 to 4.3. Runtime responses are unchanged except that 401/404 error bodies now use
+  `hydra:title`/`hydra:description` instead of the unprefixed `title` (`status`, `type` and `detail` unchanged)
 - [PR-45](https://github.com/itk-dev/event-database-api/pull/45)
   Check committed index mappings against event-database-imports@develop in CI
 - [PR-44](https://github.com/itk-dev/event-database-api/pull/44)

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
         "php": ">=8.3",
         "ext-ctype": "*",
         "ext-iconv": "*",
-        "api-platform/core": "~4.1.0",
+        "api-platform/core": "~4.3.0",
         "elasticsearch/elasticsearch": "^8.13",
         "nelmio/cors-bundle": "^2.4",
         "phpdocumentor/reflection-docblock": "^5.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,48 +4,50 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3e561e58a156313d3083e9359e0b480d",
+    "content-hash": "48d72e29a5aeb508c05569314faf8904",
     "packages": [
         {
             "name": "api-platform/core",
-            "version": "v4.1.28",
+            "version": "v4.3.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/api-platform/core.git",
-                "reference": "654f8e626ed1e3e0c084bf3a695fba551308ac95"
+                "reference": "95dd0232dd50e982d37f0590cb35ca3cefd13efa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/api-platform/core/zipball/654f8e626ed1e3e0c084bf3a695fba551308ac95",
-                "reference": "654f8e626ed1e3e0c084bf3a695fba551308ac95",
+                "url": "https://api.github.com/repos/api-platform/core/zipball/95dd0232dd50e982d37f0590cb35ca3cefd13efa",
+                "reference": "95dd0232dd50e982d37f0590cb35ca3cefd13efa",
                 "shasum": ""
             },
             "require": {
+                "composer/semver": "^3.4",
                 "doctrine/inflector": "^2.0",
                 "php": ">=8.2",
                 "psr/cache": "^1.0 || ^2.0 || ^3.0",
                 "psr/container": "^1.0 || ^2.0",
                 "symfony/deprecation-contracts": "^3.1",
-                "symfony/http-foundation": "^6.4.14 || ^7.0",
-                "symfony/http-kernel": "^6.4 || ^7.0",
-                "symfony/property-access": "^6.4 || ^7.0",
-                "symfony/property-info": "^6.4 || ^7.1",
-                "symfony/serializer": "^6.4 || ^7.0",
+                "symfony/http-foundation": "^6.4.14 || ^7.0 || ^8.0",
+                "symfony/http-kernel": "^6.4.13 || ^7.0 || ^8.0",
+                "symfony/property-access": "^6.4 || ^7.0 || ^8.0",
+                "symfony/property-info": "^6.4 || ^7.1 || ^8.0",
+                "symfony/serializer": "^6.4.37 || ^7.4.9 || ^8.0.9",
                 "symfony/translation-contracts": "^3.3",
-                "symfony/type-info": "^7.2",
-                "symfony/validator": "^6.4.11 || ^7.1",
-                "symfony/web-link": "^6.4 || ^7.1",
+                "symfony/type-info": "^7.4 || ^8.0",
+                "symfony/validator": "^6.4.11 || ^7.1 || ^8.0",
+                "symfony/web-link": "^6.4 || ^7.1 || ^8.0",
                 "willdurand/negotiation": "^3.1"
             },
             "conflict": {
                 "doctrine/common": "<3.2.2",
                 "doctrine/dbal": "<2.10",
                 "doctrine/mongodb-odm": "<2.4",
-                "doctrine/orm": "<2.14.0",
+                "doctrine/orm": "<2.14.0 || 3.0.0",
                 "doctrine/persistence": "<1.3",
                 "phpspec/prophecy": "<1.15",
                 "phpunit/phpunit": "<9.5",
                 "symfony/framework-bundle": "6.4.6 || 7.0.6",
+                "symfony/object-mapper": "<7.3.4",
                 "symfony/var-exporter": "<6.1.1"
             },
             "replace": {
@@ -55,13 +57,14 @@
                 "api-platform/documentation": "self.version",
                 "api-platform/elasticsearch": "self.version",
                 "api-platform/graphql": "self.version",
+                "api-platform/hal": "self.version",
                 "api-platform/http-cache": "self.version",
                 "api-platform/hydra": "self.version",
                 "api-platform/json-api": "self.version",
-                "api-platform/json-hal": "self.version",
                 "api-platform/json-schema": "self.version",
                 "api-platform/jsonld": "self.version",
                 "api-platform/laravel": "self.version",
+                "api-platform/mcp": "self.version",
                 "api-platform/metadata": "self.version",
                 "api-platform/openapi": "self.version",
                 "api-platform/parameter-validator": "self.version",
@@ -72,81 +75,78 @@
                 "api-platform/validator": "self.version"
             },
             "require-dev": {
-                "behat/behat": "^3.11",
-                "behat/mink": "^1.9",
-                "doctrine/cache": "^1.11 || ^2.1",
                 "doctrine/common": "^3.2.2",
                 "doctrine/dbal": "^4.0",
-                "doctrine/doctrine-bundle": "^2.11",
-                "doctrine/mongodb-odm": "^2.10",
-                "doctrine/mongodb-odm-bundle": "^5.0",
+                "doctrine/doctrine-bundle": "^2.11 || ^3.1",
                 "doctrine/orm": "^2.17 || ^3.0",
                 "elasticsearch/elasticsearch": "^7.17 || ^8.4 || ^9.0",
-                "friends-of-behat/mink-browserkit-driver": "^1.3.1",
-                "friends-of-behat/mink-extension": "^2.2",
-                "friends-of-behat/symfony-extension": "^2.1",
+                "friendsofphp/php-cs-fixer": "^3.93",
                 "guzzlehttp/guzzle": "^6.0 || ^7.0",
-                "illuminate/config": "^11.0 || ^12.0",
-                "illuminate/contracts": "^11.0 || ^12.0",
-                "illuminate/database": "^11.0 || ^12.0",
-                "illuminate/http": "^11.0 || ^12.0",
-                "illuminate/pagination": "^11.0 || ^12.0",
-                "illuminate/routing": "^11.0 || ^12.0",
-                "illuminate/support": "^11.0 || ^12.0",
-                "jangregor/phpstan-prophecy": "^1.0",
-                "justinrainbow/json-schema": "^5.2.11",
-                "laravel/framework": "^11.0 || ^12.0",
-                "orchestra/testbench": "^9.1",
+                "illuminate/config": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/contracts": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/database": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/http": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/pagination": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/routing": "^11.0 || ^12.0 || ^13.0",
+                "illuminate/support": "^11.0 || ^12.0 || ^13.0",
+                "jangregor/phpstan-prophecy": "^2.1.11",
+                "justinrainbow/json-schema": "^6.5.2",
+                "laravel/framework": "^11.0 || ^12.0 || ^13.0",
+                "mcp/sdk": "^0.6",
+                "orchestra/testbench": "^10.9 || ^11.0",
                 "phpspec/prophecy-phpunit": "^2.2",
                 "phpstan/extension-installer": "^1.1",
                 "phpstan/phpdoc-parser": "^1.29 || ^2.0",
-                "phpstan/phpstan": "^1.10",
-                "phpstan/phpstan-doctrine": "^1.0",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpstan/phpstan-symfony": "^1.0",
-                "phpunit/phpunit": "11.5.x-dev",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-doctrine": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-symfony": "^2.0",
+                "phpunit/phpunit": "^11.5 || ^12.2",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "ramsey/uuid": "^4.7",
                 "ramsey/uuid-doctrine": "^2.0",
-                "soyuka/contexts": "^3.3.10",
                 "soyuka/pmu": "^0.2.0",
                 "soyuka/stubs-mongodb": "^1.0",
-                "symfony/asset": "^6.4 || ^7.0",
-                "symfony/browser-kit": "^6.4 || ^7.0",
-                "symfony/cache": "^6.4 || ^7.0",
-                "symfony/config": "^6.4 || ^7.0",
-                "symfony/console": "^6.4 || ^7.0",
-                "symfony/css-selector": "^6.4 || ^7.0",
-                "symfony/dependency-injection": "^6.4 || ^7.0",
-                "symfony/doctrine-bridge": "^6.4.2 || ^7.0.2",
-                "symfony/dom-crawler": "^6.4 || ^7.0",
-                "symfony/error-handler": "^6.4 || ^7.0",
-                "symfony/event-dispatcher": "^6.4 || ^7.0",
-                "symfony/expression-language": "^6.4 || ^7.0",
-                "symfony/finder": "^6.4 || ^7.0",
-                "symfony/form": "^6.4 || ^7.0",
-                "symfony/framework-bundle": "^6.4 || ^7.0",
-                "symfony/http-client": "^6.4 || ^7.0",
-                "symfony/intl": "^6.4 || ^7.0",
+                "symfony/asset": "^6.4 || ^7.0 || ^8.0",
+                "symfony/browser-kit": "^6.4 || ^7.0 || ^8.0",
+                "symfony/cache": "^6.4 || ^7.0 || ^8.0",
+                "symfony/config": "^6.4 || ^7.0 || ^8.0",
+                "symfony/console": "^6.4 || ^7.0 || ^8.0",
+                "symfony/css-selector": "^6.4 || ^7.0 || ^8.0",
+                "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
+                "symfony/doctrine-bridge": "^6.4.2 || ^7.1 || ^8.0",
+                "symfony/dom-crawler": "^6.4 || ^7.0 || ^8.0",
+                "symfony/error-handler": "^6.4 || ^7.0 || ^8.0",
+                "symfony/event-dispatcher": "^6.4 || ^7.0 || ^8.0",
+                "symfony/expression-language": "^6.4 || ^7.0 || ^8.0",
+                "symfony/finder": "^6.4 || ^7.0 || ^8.0",
+                "symfony/form": "^6.4 || ^7.0 || ^8.0",
+                "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/http-client": "^6.4 || ^7.0 || ^8.0",
+                "symfony/intl": "^6.4 || ^7.0 || ^8.0",
+                "symfony/json-streamer": "^7.4 || ^8.0",
                 "symfony/maker-bundle": "^1.24",
+                "symfony/mcp-bundle": "dev-main",
                 "symfony/mercure-bundle": "*",
-                "symfony/messenger": "^6.4 || ^7.0",
-                "symfony/routing": "^6.4 || ^7.0",
-                "symfony/security-bundle": "^6.4 || ^7.0",
-                "symfony/security-core": "^6.4 || ^7.0",
-                "symfony/stopwatch": "^6.4 || ^7.0",
-                "symfony/string": "^6.4 || ^7.0",
-                "symfony/twig-bundle": "^6.4 || ^7.0",
-                "symfony/uid": "^6.4 || ^7.0",
-                "symfony/web-profiler-bundle": "^6.4 || ^7.0",
-                "symfony/yaml": "^6.4 || ^7.0",
+                "symfony/messenger": "^6.4 || ^7.0 || ^8.0",
+                "symfony/object-mapper": "^7.4 || ^8.0",
+                "symfony/routing": "^6.4 || ^7.0 || ^8.0",
+                "symfony/security-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/security-core": "^6.4 || ^7.0 || ^8.0",
+                "symfony/stopwatch": "^6.4 || ^7.0 || ^8.0",
+                "symfony/string": "^6.4 || ^7.0 || ^8.0",
+                "symfony/twig-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/uid": "^6.4 || ^7.0 || ^8.0",
+                "symfony/var-exporter": "^7.4 || ^8.0",
+                "symfony/web-profiler-bundle": "^6.4 || ^7.0 || ^8.0",
+                "symfony/yaml": "^6.4 || ^7.0 || ^8.0",
                 "twig/twig": "^1.42.3 || ^2.12 || ^3.0",
                 "webonyx/graphql-php": "^15.0"
             },
             "suggest": {
                 "doctrine/mongodb-odm-bundle": "To support MongoDB. Only versions 4.0 and later are supported.",
                 "elasticsearch/elasticsearch": "To support Elasticsearch.",
-                "ocramius/package-versions": "To display the API Platform's version in the debug bar.",
+                "opensearch-project/opensearch-php": "To support OpenSearch (^2.5).",
                 "phpstan/phpdoc-parser": "To support extracting metadata from PHPDoc.",
                 "psr/cache-implementation": "To use metadata caching.",
                 "ramsey/uuid": "To support Ramsey's UUID identifiers.",
@@ -154,6 +154,7 @@
                 "symfony/config": "To load XML configuration files.",
                 "symfony/expression-language": "To use authorization features.",
                 "symfony/http-client": "To use the HTTP cache invalidation system.",
+                "symfony/json-streamer": "To use the JSON Streamer component.",
                 "symfony/messenger": "To support messenger integration.",
                 "symfony/security": "To use authorization features.",
                 "symfony/twig-bundle": "To use the Swagger UI integration.",
@@ -174,12 +175,13 @@
                     "name": "api-platform/api-platform"
                 },
                 "symfony": {
-                    "require": "^6.4 || ^7.1"
+                    "require": "^6.4 || ^7.1 || ^8.0"
                 },
                 "branch-alias": {
                     "dev-3.4": "3.4.x-dev",
                     "dev-4.1": "4.1.x-dev",
-                    "dev-main": "4.2.x-dev"
+                    "dev-4.2": "4.2.x-dev",
+                    "dev-main": "4.4.x-dev"
                 }
             },
             "autoload": {
@@ -218,9 +220,86 @@
             ],
             "support": {
                 "issues": "https://github.com/api-platform/core/issues",
-                "source": "https://github.com/api-platform/core/tree/v4.1.28"
+                "source": "https://github.com/api-platform/core/tree/v4.3.16"
             },
-            "time": "2025-12-05T14:51:01+00:00"
+            "time": "2026-07-03T06:59:33+00:00"
+        },
+        {
+            "name": "composer/semver",
+            "version": "3.4.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/semver.git",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.3.2 || ^7.0 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Composer\\Semver\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nils Adermann",
+                    "email": "naderman@naderman.de",
+                    "homepage": "http://www.naderman.de"
+                },
+                {
+                    "name": "Jordi Boggiano",
+                    "email": "j.boggiano@seld.be",
+                    "homepage": "http://seld.be"
+                },
+                {
+                    "name": "Rob Bast",
+                    "email": "rob.bast@gmail.com",
+                    "homepage": "http://robbast.nl"
+                }
+            ],
+            "description": "Semver library that offers utilities, version constraint parsing and validation.",
+            "keywords": [
+                "semantic",
+                "semver",
+                "validation",
+                "versioning"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/semver/issues",
+                "source": "https://github.com/composer/semver/tree/3.4.4"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -5092,16 +5171,16 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "v7.4.10",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "268c5aa6c4bd675eddd89348e7ecac292a843ddd"
+                "reference": "55acb01b9c8a5211dfbaf68c314d90d0ed2cc3d1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/268c5aa6c4bd675eddd89348e7ecac292a843ddd",
-                "reference": "268c5aa6c4bd675eddd89348e7ecac292a843ddd",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/55acb01b9c8a5211dfbaf68c314d90d0ed2cc3d1",
+                "reference": "55acb01b9c8a5211dfbaf68c314d90d0ed2cc3d1",
                 "shasum": ""
             },
             "require": {
@@ -5172,7 +5251,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v7.4.10"
+                "source": "https://github.com/symfony/serializer/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5192,7 +5271,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-03T13:03:28+00:00"
+            "time": "2026-06-27T08:31:18+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -5374,16 +5453,16 @@
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.7.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d"
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/0ab302977a952b42fd51475c4ebac81f8da0a95d",
-                "reference": "0ab302977a952b42fd51475c4ebac81f8da0a95d",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621",
                 "shasum": ""
             },
             "require": {
@@ -5432,7 +5511,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.0"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -5452,7 +5531,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T13:30:16+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/twig-bridge",
@@ -5744,16 +5823,16 @@
         },
         {
             "name": "symfony/validator",
-            "version": "v7.4.10",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/validator.git",
-                "reference": "c76458623af9a3fe3b2e5b09b36453f334c2a361"
+                "reference": "306d904336166d001751759351d40d5e82312596"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/validator/zipball/c76458623af9a3fe3b2e5b09b36453f334c2a361",
-                "reference": "c76458623af9a3fe3b2e5b09b36453f334c2a361",
+                "url": "https://api.github.com/repos/symfony/validator/zipball/306d904336166d001751759351d40d5e82312596",
+                "reference": "306d904336166d001751759351d40d5e82312596",
                 "shasum": ""
             },
             "require": {
@@ -5824,7 +5903,7 @@
             "description": "Provides tools to validate values",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/validator/tree/v7.4.10"
+                "source": "https://github.com/symfony/validator/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5844,7 +5923,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-05T15:30:56+00:00"
+            "time": "2026-06-27T06:16:12+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -6520,83 +6599,6 @@
                 }
             ],
             "time": "2026-06-07T11:47:49+00:00"
-        },
-        {
-            "name": "composer/semver",
-            "version": "3.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/composer/semver.git",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/composer/semver/zipball/198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "reference": "198166618906cb2de69b95d7d47e5fa8aa1b2b95",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.3.2 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.11",
-                "symfony/phpunit-bridge": "^3 || ^7"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Composer\\Semver\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nils Adermann",
-                    "email": "naderman@naderman.de",
-                    "homepage": "http://www.naderman.de"
-                },
-                {
-                    "name": "Jordi Boggiano",
-                    "email": "j.boggiano@seld.be",
-                    "homepage": "http://seld.be"
-                },
-                {
-                    "name": "Rob Bast",
-                    "email": "rob.bast@gmail.com",
-                    "homepage": "http://robbast.nl"
-                }
-            ],
-            "description": "Semver library that offers utilities, version constraint parsing and validation.",
-            "keywords": [
-                "semantic",
-                "semver",
-                "validation",
-                "versioning"
-            ],
-            "support": {
-                "irc": "ircs://irc.libera.chat:6697/composer",
-                "issues": "https://github.com/composer/semver/issues",
-                "source": "https://github.com/composer/semver/tree/3.4.4"
-            },
-            "funding": [
-                {
-                    "url": "https://packagist.com",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/composer",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-08-20T19:15:30+00:00"
         },
         {
             "name": "composer/xdebug-handler",

--- a/config/reference.php
+++ b/config/reference.php
@@ -1069,7 +1069,11 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     inflector?: scalar|Param|null, // Specify an inflector to use. // Default: "api_platform.metadata.inflector"
  *     validator?: array{
  *         serialize_payload_fields?: mixed, // Set to null to serialize all payload fields when a validation error is thrown, or set the fields you want to include explicitly. // Default: []
- *         query_parameter_validation?: bool|Param, // Default: true
+ *         query_parameter_validation?: bool|Param, // Deprecated: Will be removed in API Platform 5.0. // Default: true
+ *     },
+ *     jsonapi?: array{
+ *         use_iri_as_id?: bool|Param, // Set to false to use entity identifiers instead of IRIs as the "id" field in JSON:API responses. // Default: true
+ *         allow_client_generated_id?: bool|Param, // Allow client-generated IDs on JSON:API POST per https://jsonapi.org/format/#crud-creating-client-ids. Off by default to prevent id spoofing on public endpoints. // Default: false
  *     },
  *     eager_loading?: bool|array{
  *         enabled?: bool|Param, // Default: true
@@ -1079,13 +1083,15 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     },
  *     handle_symfony_errors?: bool|Param, // Allows to handle symfony exceptions. // Default: false
  *     enable_swagger?: bool|Param, // Enable the Swagger documentation and export. // Default: true
+ *     enable_json_streamer?: bool|Param, // Enable json streamer. // Default: false
  *     enable_swagger_ui?: bool|Param, // Enable Swagger UI // Default: true
  *     enable_re_doc?: bool|Param, // Enable ReDoc // Default: true
+ *     enable_scalar?: bool|Param, // Enable Scalar API Reference // Default: true
  *     enable_entrypoint?: bool|Param, // Enable the entrypoint // Default: true
  *     enable_docs?: bool|Param, // Enable the docs // Default: true
  *     enable_profiler?: bool|Param, // Enable the data collector and the WebProfilerBundle integration. // Default: true
  *     enable_phpdoc_parser?: bool|Param, // Enable resource metadata collector using PHPStan PhpDocParser. // Default: true
- *     enable_link_security?: bool|Param, // Enable security for Links (sub resources) // Default: false
+ *     enable_link_security?: bool|Param, // Deprecated: This option is always enabled and will be removed in API Platform 5.0. // Enable security for Links (sub resources). // Default: true
  *     collection?: array{
  *         exists_parameter_name?: scalar|Param|null, // The name of the query parameter to filter on nullable field values. // Default: "exists"
  *         order?: scalar|Param|null, // The default order of results. // Default: "ASC"
@@ -1100,6 +1106,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         },
  *     },
  *     mapping?: array{
+ *         imports?: list<scalar|Param|null>,
  *         paths?: list<scalar|Param|null>,
  *     },
  *     resource_class_directories?: list<scalar|Param|null>,
@@ -1134,7 +1141,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             enabled?: bool|Param, // Default: true
  *         },
  *         max_query_depth?: int|Param, // Default: 20
- *         graphql_playground?: array<mixed>,
+ *         graphql_playground?: bool|array{ // Deprecated: The "graphql_playground" configuration is deprecated and will be ignored.
+ *             enabled?: bool|Param, // Default: false
+ *         },
  *         max_query_complexity?: int|Param, // Default: 500
  *         nesting_separator?: scalar|Param|null, // The separator to use to filter nested fields. // Default: "_"
  *         collection?: array{
@@ -1166,7 +1175,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *             max_header_length?: int|Param, // Max header length supported by the cache server. // Default: 7500
  *             request_options?: mixed, // To pass options to the client charged with the request. // Default: []
  *             purger?: scalar|Param|null, // Specify a purger to use (available values: "api_platform.http_cache.purger.varnish.ban", "api_platform.http_cache.purger.varnish.xkey", "api_platform.http_cache.purger.souin"). // Default: "api_platform.http_cache.purger.varnish"
- *             xkey?: array{ // Deprecated: The "xkey" configuration is deprecated, use your own purger to customize surrogate keys or the appropriate paramters.
+ *             xkey?: array{ // Deprecated: The "xkey" configuration is deprecated, use your own purger to customize surrogate keys or the appropriate parameters.
  *                 glue?: scalar|Param|null, // xkey glue between keys // Default: " "
  *             },
  *         },
@@ -1182,6 +1191,9 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *     elasticsearch?: bool|array{
  *         enabled?: bool|Param, // Default: false
  *         hosts?: list<scalar|Param|null>,
+ *         ssl_ca_bundle?: scalar|Param|null, // Path to the SSL CA bundle file for Elasticsearch SSL verification. // Default: null
+ *         ssl_verification?: bool|Param, // Enable or disable SSL verification for Elasticsearch connections. // Default: true
+ *         client?: "elasticsearch"|"opensearch"|Param, // The search engine client to use: "elasticsearch" or "opensearch". // Default: "elasticsearch"
  *     },
  *     openapi?: array{
  *         contact?: array{
@@ -1197,12 +1209,21 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         license?: array{
  *             name?: scalar|Param|null, // The license name used for the API. // Default: null
  *             url?: scalar|Param|null, // URL to the license used for the API. MUST be in the format of a URL. // Default: null
+ *             identifier?: scalar|Param|null, // An SPDX license expression for the API. The identifier field is mutually exclusive of the url field. // Default: null
  *         },
  *         swagger_ui_extra_configuration?: mixed, // To pass extra configuration to Swagger UI, like docExpansion or filter. // Default: []
+ *         scalar_extra_configuration?: mixed, // To pass extra configuration to Scalar API Reference, like theme or darkMode. // Default: []
  *         overrideResponses?: bool|Param, // Whether API Platform adds automatic responses to the OpenAPI documentation. // Default: true
+ *         error_resource_class?: scalar|Param|null, // The class used to represent errors in the OpenAPI documentation. // Default: null
+ *         validation_error_resource_class?: scalar|Param|null, // The class used to represent validation errors in the OpenAPI documentation. // Default: null
  *     },
  *     maker?: bool|array{
  *         enabled?: bool|Param, // Default: true
+ *         namespace_prefix?: scalar|Param|null, // Add a prefix to all maker generated classes. e.g set it to "Api" to set the maker namespace to "App\Api\" (if the maker.root_namespace config is App). e.g. App\Api\State\MyStateProcessor // Default: ""
+ *     },
+ *     mcp?: bool|array{
+ *         enabled?: bool|Param, // Default: true
+ *         format?: scalar|Param|null, // The serialization format used for MCP tool input/output. Must be a format registered in api_platform.formats (e.g. "jsonld", "json", "jsonapi"). // Default: "jsonld"
  *     },
  *     exception_to_status?: array<string, int|Param>,
  *     formats?: array<string, array{ // Default: {"jsonld":{"mime_types":["application/ld+json"]}}
@@ -1287,10 +1308,37 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         rules?: mixed,
  *         policy?: mixed,
  *         middleware?: mixed,
- *         parameters?: mixed,
+ *         parameters?: array<string, array{ // Default: []
+ *             key?: mixed,
+ *             schema?: mixed,
+ *             open_api?: mixed,
+ *             provider?: mixed,
+ *             filter?: mixed,
+ *             property?: mixed,
+ *             description?: mixed,
+ *             properties?: mixed,
+ *             required?: mixed,
+ *             priority?: mixed,
+ *             hydra?: mixed,
+ *             constraints?: mixed,
+ *             security?: mixed,
+ *             security_message?: mixed,
+ *             extra_properties?: mixed,
+ *             filter_context?: mixed,
+ *             native_type?: mixed,
+ *             cast_to_array?: mixed,
+ *             cast_to_native_type?: mixed,
+ *             cast_fn?: mixed,
+ *             default?: mixed,
+ *             filter_class?: mixed,
+ *             ...<string, mixed>
+ *         }>,
  *         strict_query_parameter_validation?: mixed,
  *         hide_hydra_operation?: mixed,
+ *         json_stream?: mixed,
  *         extra_properties?: mixed,
+ *         map?: mixed,
+ *         mcp?: mixed,
  *         route_name?: mixed,
  *         errors?: mixed,
  *         read?: mixed,
@@ -1298,6 +1346,7 @@ use Symfony\Component\Config\Loader\ParamConfigurator as Param;
  *         validate?: mixed,
  *         write?: mixed,
  *         serialize?: mixed,
+ *         content_negotiation?: mixed,
  *         priority?: mixed,
  *         name?: mixed,
  *         allow_create?: mixed,

--- a/public/spec.yaml
+++ b/public/spec.yaml
@@ -25,13 +25,10 @@ paths:
             application/ld+json:
               schema:
                 type: object
-                properties:
-                  'hydra:member': { type: array, items: { $ref: '#/components/schemas/DailyOccurrence.DailyOccurrenceRepresentationProvider.jsonld' } }
-                  'hydra:totalItems': { type: integer, minimum: 0 }
-                  'hydra:view': { type: object, properties: { '@id': { type: string, format: iri-reference }, '@type': { type: string }, 'hydra:first': { type: string, format: iri-reference }, 'hydra:last': { type: string, format: iri-reference }, 'hydra:previous': { type: string, format: iri-reference }, 'hydra:next': { type: string, format: iri-reference } }, example: { '@id': string, type: string, 'hydra:first': string, 'hydra:last': string, 'hydra:previous': string, 'hydra:next': string } }
-                  'hydra:search': { type: object, properties: { '@type': { type: string }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string }, 'hydra:mapping': { type: array, items: { type: object, properties: { '@type': { type: string }, variable: { type: string }, property: { type: [string, 'null'] }, required: { type: boolean } } } } } }
-                required:
-                  - 'hydra:member'
+                description: 'DailyOccurrence.DailyOccurrenceRepresentationProvider.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: ['hydra:member'], properties: { 'hydra:member': { type: array, items: { $ref: '#/components/schemas/DailyOccurrence.DailyOccurrenceRepresentationProvider.jsonld' } } } }
       summary: 'Retrieves the collection of DailyOccurrence resources.'
       description: 'Retrieves the collection of DailyOccurrence resources.'
       parameters:
@@ -41,28 +38,24 @@ paths:
           description: 'The collection page number'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 1
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: itemsPerPage
           in: query
           description: 'The number of items per page'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 10
             minimum: 0
             maximum: 50
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: event.title
           in: query
@@ -159,217 +152,180 @@ paths:
           description: 'Filter based on start greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00" (DEPRECATED - please use a filter with an explicit operator, e.g. start[gt]=2004-02-12T15:19:21+00:00) '
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'start[between]'
           in: query
           description: "Filter based on start between two ISO 8601 datetime [(yyyy-MM-dd'T'HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns) seperated by '..', e.g. \"2004-02-12T15:19:21+00:00..2004-02-13T16:20:22+00:00\""
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'start[gt]'
           in: query
           description: 'Filter based on start greater than ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'start[gte]'
           in: query
           description: 'Filter based on start greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'start[lt]'
           in: query
           description: 'Filter based on start less then ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'start[lte]'
           in: query
           description: 'Filter based on start less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: end
           in: query
           description: 'Filter based on end less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00" (DEPRECATED - please use a filter with an explicit operator, e.g. end[gt]=2004-02-12T15:19:21+00:00) '
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'end[between]'
           in: query
           description: "Filter based on end between two ISO 8601 datetime [(yyyy-MM-dd'T'HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns) seperated by '..', e.g. \"2004-02-12T15:19:21+00:00..2004-02-13T16:20:22+00:00\""
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'end[gt]'
           in: query
           description: 'Filter based on end greater than ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'end[gte]'
           in: query
           description: 'Filter based on end greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'end[lt]'
           in: query
           description: 'Filter based on end less then ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'end[lte]'
           in: query
           description: 'Filter based on end less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: updated
           in: query
           description: 'Filter based on updated greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00" (DEPRECATED - please use a filter with an explicit operator, e.g. updated[gt]=2004-02-12T15:19:21+00:00) '
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[between]'
           in: query
           description: "Filter based on updated between two ISO 8601 datetime [(yyyy-MM-dd'T'HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns) seperated by '..', e.g. \"2004-02-12T15:19:21+00:00..2004-02-13T16:20:22+00:00\""
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[gt]'
           in: query
           description: 'Filter based on updated greater than ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[gte]'
           in: query
           description: 'Filter based on updated greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[lt]'
           in: query
           description: 'Filter based on updated less then ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[lte]'
           in: query
           description: 'Filter based on updated less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
-      deprecated: false
   '/api/v2/daily_occurrences/{id}':
     get:
       operationId: api_daily_occurrences_id_get
@@ -378,6 +334,10 @@ paths:
       responses:
         '200':
           description: 'Single daily occurrence'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/DailyOccurrence.DailyOccurrenceRepresentationProvider.jsonld'
         '404':
           description: 'Not found'
           content:
@@ -397,16 +357,13 @@ paths:
         -
           name: id
           in: path
-          description: ''
+          description: 'DailyOccurrence identifier'
           required: true
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: integer
           style: simple
           explode: false
-          allowReserved: false
-      deprecated: false
   /api/v2/events:
     get:
       operationId: api_events_get_collection
@@ -419,13 +376,10 @@ paths:
             application/ld+json:
               schema:
                 type: object
-                properties:
-                  'hydra:member': { type: array, items: { $ref: '#/components/schemas/Event.EventRepresentationProvider.jsonld' } }
-                  'hydra:totalItems': { type: integer, minimum: 0 }
-                  'hydra:view': { type: object, properties: { '@id': { type: string, format: iri-reference }, '@type': { type: string }, 'hydra:first': { type: string, format: iri-reference }, 'hydra:last': { type: string, format: iri-reference }, 'hydra:previous': { type: string, format: iri-reference }, 'hydra:next': { type: string, format: iri-reference } }, example: { '@id': string, type: string, 'hydra:first': string, 'hydra:last': string, 'hydra:previous': string, 'hydra:next': string } }
-                  'hydra:search': { type: object, properties: { '@type': { type: string }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string }, 'hydra:mapping': { type: array, items: { type: object, properties: { '@type': { type: string }, variable: { type: string }, property: { type: [string, 'null'] }, required: { type: boolean } } } } } }
-                required:
-                  - 'hydra:member'
+                description: 'Event.EventRepresentationProvider.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: ['hydra:member'], properties: { 'hydra:member': { type: array, items: { $ref: '#/components/schemas/Event.EventRepresentationProvider.jsonld' } } } }
       summary: 'Retrieves the collection of Event resources.'
       description: 'Retrieves the collection of Event resources.'
       parameters:
@@ -435,28 +389,24 @@ paths:
           description: 'The collection page number'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 1
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: itemsPerPage
           in: query
           description: 'The number of items per page'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 10
             minimum: 0
             maximum: 50
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: title
           in: query
@@ -553,217 +503,180 @@ paths:
           description: 'Filter based on occurrences.start greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00" (DEPRECATED - please use a filter with an explicit operator, e.g. occurrences.start[gt]=2004-02-12T15:19:21+00:00) '
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'occurrences.start[between]'
           in: query
           description: "Filter based on occurrences.start between two ISO 8601 datetime [(yyyy-MM-dd'T'HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns) seperated by '..', e.g. \"2004-02-12T15:19:21+00:00..2004-02-13T16:20:22+00:00\""
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'occurrences.start[gt]'
           in: query
           description: 'Filter based on occurrences.start greater than ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'occurrences.start[gte]'
           in: query
           description: 'Filter based on occurrences.start greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'occurrences.start[lt]'
           in: query
           description: 'Filter based on occurrences.start less then ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'occurrences.start[lte]'
           in: query
           description: 'Filter based on occurrences.start less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: occurrences.end
           in: query
           description: 'Filter based on occurrences.end less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00" (DEPRECATED - please use a filter with an explicit operator, e.g. occurrences.end[gt]=2004-02-12T15:19:21+00:00) '
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'occurrences.end[between]'
           in: query
           description: "Filter based on occurrences.end between two ISO 8601 datetime [(yyyy-MM-dd'T'HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns) seperated by '..', e.g. \"2004-02-12T15:19:21+00:00..2004-02-13T16:20:22+00:00\""
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'occurrences.end[gt]'
           in: query
           description: 'Filter based on occurrences.end greater than ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'occurrences.end[gte]'
           in: query
           description: 'Filter based on occurrences.end greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'occurrences.end[lt]'
           in: query
           description: 'Filter based on occurrences.end less then ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'occurrences.end[lte]'
           in: query
           description: 'Filter based on occurrences.end less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: updated
           in: query
           description: 'Filter based on updated greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00" (DEPRECATED - please use a filter with an explicit operator, e.g. updated[gt]=2004-02-12T15:19:21+00:00) '
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[between]'
           in: query
           description: "Filter based on updated between two ISO 8601 datetime [(yyyy-MM-dd'T'HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns) seperated by '..', e.g. \"2004-02-12T15:19:21+00:00..2004-02-13T16:20:22+00:00\""
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[gt]'
           in: query
           description: 'Filter based on updated greater than ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[gte]'
           in: query
           description: 'Filter based on updated greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[lt]'
           in: query
           description: 'Filter based on updated less then ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[lte]'
           in: query
           description: 'Filter based on updated less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
-      deprecated: false
   '/api/v2/events/{id}':
     get:
       operationId: api_events_id_get
@@ -772,6 +685,10 @@ paths:
       responses:
         '200':
           description: 'Single event'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Event.EventRepresentationProvider.jsonld'
         '404':
           description: 'Not found'
           content:
@@ -791,16 +708,13 @@ paths:
         -
           name: id
           in: path
-          description: ''
+          description: 'Event identifier'
           required: true
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: integer
           style: simple
           explode: false
-          allowReserved: false
-      deprecated: false
   /api/v2/locations:
     get:
       operationId: api_locations_get_collection
@@ -813,13 +727,10 @@ paths:
             application/ld+json:
               schema:
                 type: object
-                properties:
-                  'hydra:member': { type: array, items: { $ref: '#/components/schemas/Location.LocationRepresentationProvider.jsonld' } }
-                  'hydra:totalItems': { type: integer, minimum: 0 }
-                  'hydra:view': { type: object, properties: { '@id': { type: string, format: iri-reference }, '@type': { type: string }, 'hydra:first': { type: string, format: iri-reference }, 'hydra:last': { type: string, format: iri-reference }, 'hydra:previous': { type: string, format: iri-reference }, 'hydra:next': { type: string, format: iri-reference } }, example: { '@id': string, type: string, 'hydra:first': string, 'hydra:last': string, 'hydra:previous': string, 'hydra:next': string } }
-                  'hydra:search': { type: object, properties: { '@type': { type: string }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string }, 'hydra:mapping': { type: array, items: { type: object, properties: { '@type': { type: string }, variable: { type: string }, property: { type: [string, 'null'] }, required: { type: boolean } } } } } }
-                required:
-                  - 'hydra:member'
+                description: 'Location.LocationRepresentationProvider.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: ['hydra:member'], properties: { 'hydra:member': { type: array, items: { $ref: '#/components/schemas/Location.LocationRepresentationProvider.jsonld' } } } }
       summary: 'Retrieves the collection of Location resources.'
       description: 'Retrieves the collection of Location resources.'
       parameters:
@@ -829,28 +740,24 @@ paths:
           description: 'The collection page number'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 1
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: itemsPerPage
           in: query
           description: 'The number of items per page'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 20
             minimum: 0
             maximum: 100
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: name
           in: query
@@ -881,73 +788,60 @@ paths:
           description: 'Filter based on updated greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00" (DEPRECATED - please use a filter with an explicit operator, e.g. updated[gt]=2004-02-12T15:19:21+00:00) '
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[between]'
           in: query
           description: "Filter based on updated between two ISO 8601 datetime [(yyyy-MM-dd'T'HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns) seperated by '..', e.g. \"2004-02-12T15:19:21+00:00..2004-02-13T16:20:22+00:00\""
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[gt]'
           in: query
           description: 'Filter based on updated greater than ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[gte]'
           in: query
           description: 'Filter based on updated greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[lt]'
           in: query
           description: 'Filter based on updated less then ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[lte]'
           in: query
           description: 'Filter based on updated less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
-      deprecated: false
   '/api/v2/locations/{id}':
     get:
       operationId: api_locations_id_get
@@ -956,6 +850,10 @@ paths:
       responses:
         '200':
           description: 'Single location'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Location.LocationRepresentationProvider.jsonld'
         '404':
           description: 'Not found'
           content:
@@ -970,21 +868,18 @@ paths:
                 $ref: '#/components/schemas/Error'
           links: {  }
       summary: 'Get single location based on identifier'
-      description: 'Retrieves a Location resource.'
+      description: 'Get single location based on identifier'
       parameters:
         -
           name: id
           in: path
-          description: ''
+          description: 'Location identifier'
           required: true
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: integer
           style: simple
           explode: false
-          allowReserved: false
-      deprecated: false
   /api/v2/occurrences:
     get:
       operationId: api_occurrences_get_collection
@@ -997,13 +892,10 @@ paths:
             application/ld+json:
               schema:
                 type: object
-                properties:
-                  'hydra:member': { type: array, items: { $ref: '#/components/schemas/Occurrence.OccurrenceRepresentationProvider.jsonld' } }
-                  'hydra:totalItems': { type: integer, minimum: 0 }
-                  'hydra:view': { type: object, properties: { '@id': { type: string, format: iri-reference }, '@type': { type: string }, 'hydra:first': { type: string, format: iri-reference }, 'hydra:last': { type: string, format: iri-reference }, 'hydra:previous': { type: string, format: iri-reference }, 'hydra:next': { type: string, format: iri-reference } }, example: { '@id': string, type: string, 'hydra:first': string, 'hydra:last': string, 'hydra:previous': string, 'hydra:next': string } }
-                  'hydra:search': { type: object, properties: { '@type': { type: string }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string }, 'hydra:mapping': { type: array, items: { type: object, properties: { '@type': { type: string }, variable: { type: string }, property: { type: [string, 'null'] }, required: { type: boolean } } } } } }
-                required:
-                  - 'hydra:member'
+                description: 'Occurrence.OccurrenceRepresentationProvider.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: ['hydra:member'], properties: { 'hydra:member': { type: array, items: { $ref: '#/components/schemas/Occurrence.OccurrenceRepresentationProvider.jsonld' } } } }
       summary: 'Retrieves the collection of Occurrence resources.'
       description: 'Retrieves the collection of Occurrence resources.'
       parameters:
@@ -1013,28 +905,24 @@ paths:
           description: 'The collection page number'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 1
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: itemsPerPage
           in: query
           description: 'The number of items per page'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 10
             minimum: 0
             maximum: 50
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: event.title
           in: query
@@ -1119,217 +1007,180 @@ paths:
           description: 'Filter based on start greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00" (DEPRECATED - please use a filter with an explicit operator, e.g. start[gt]=2004-02-12T15:19:21+00:00) '
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'start[between]'
           in: query
           description: "Filter based on start between two ISO 8601 datetime [(yyyy-MM-dd'T'HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns) seperated by '..', e.g. \"2004-02-12T15:19:21+00:00..2004-02-13T16:20:22+00:00\""
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'start[gt]'
           in: query
           description: 'Filter based on start greater than ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'start[gte]'
           in: query
           description: 'Filter based on start greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'start[lt]'
           in: query
           description: 'Filter based on start less then ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'start[lte]'
           in: query
           description: 'Filter based on start less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: end
           in: query
           description: 'Filter based on end less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00" (DEPRECATED - please use a filter with an explicit operator, e.g. end[gt]=2004-02-12T15:19:21+00:00) '
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'end[between]'
           in: query
           description: "Filter based on end between two ISO 8601 datetime [(yyyy-MM-dd'T'HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns) seperated by '..', e.g. \"2004-02-12T15:19:21+00:00..2004-02-13T16:20:22+00:00\""
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'end[gt]'
           in: query
           description: 'Filter based on end greater than ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'end[gte]'
           in: query
           description: 'Filter based on end greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'end[lt]'
           in: query
           description: 'Filter based on end less then ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'end[lte]'
           in: query
           description: 'Filter based on end less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: updated
           in: query
           description: 'Filter based on updated greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00" (DEPRECATED - please use a filter with an explicit operator, e.g. updated[gt]=2004-02-12T15:19:21+00:00) '
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[between]'
           in: query
           description: "Filter based on updated between two ISO 8601 datetime [(yyyy-MM-dd'T'HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns) seperated by '..', e.g. \"2004-02-12T15:19:21+00:00..2004-02-13T16:20:22+00:00\""
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[gt]'
           in: query
           description: 'Filter based on updated greater than ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[gte]'
           in: query
           description: 'Filter based on updated greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[lt]'
           in: query
           description: 'Filter based on updated less then ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[lte]'
           in: query
           description: 'Filter based on updated less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
-      deprecated: false
   '/api/v2/occurrences/{id}':
     get:
       operationId: api_occurrences_id_get
@@ -1338,6 +1189,10 @@ paths:
       responses:
         '200':
           description: 'Single occurrence'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Occurrence.OccurrenceRepresentationProvider.jsonld'
         '404':
           description: 'Not found'
           content:
@@ -1352,21 +1207,18 @@ paths:
                 $ref: '#/components/schemas/Error'
           links: {  }
       summary: 'Get single occurrence based on identifier'
-      description: 'Retrieves a Occurrence resource.'
+      description: 'Get single occurrence based on identifier'
       parameters:
         -
           name: id
           in: path
-          description: ''
+          description: 'Occurrence identifier'
           required: true
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: integer
           style: simple
           explode: false
-          allowReserved: false
-      deprecated: false
   /api/v2/organizations:
     get:
       operationId: api_organizations_get_collection
@@ -1379,13 +1231,10 @@ paths:
             application/ld+json:
               schema:
                 type: object
-                properties:
-                  'hydra:member': { type: array, items: { $ref: '#/components/schemas/Organization.OrganizationRepresentationProvider.jsonld' } }
-                  'hydra:totalItems': { type: integer, minimum: 0 }
-                  'hydra:view': { type: object, properties: { '@id': { type: string, format: iri-reference }, '@type': { type: string }, 'hydra:first': { type: string, format: iri-reference }, 'hydra:last': { type: string, format: iri-reference }, 'hydra:previous': { type: string, format: iri-reference }, 'hydra:next': { type: string, format: iri-reference } }, example: { '@id': string, type: string, 'hydra:first': string, 'hydra:last': string, 'hydra:previous': string, 'hydra:next': string } }
-                  'hydra:search': { type: object, properties: { '@type': { type: string }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string }, 'hydra:mapping': { type: array, items: { type: object, properties: { '@type': { type: string }, variable: { type: string }, property: { type: [string, 'null'] }, required: { type: boolean } } } } } }
-                required:
-                  - 'hydra:member'
+                description: 'Organization.OrganizationRepresentationProvider.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: ['hydra:member'], properties: { 'hydra:member': { type: array, items: { $ref: '#/components/schemas/Organization.OrganizationRepresentationProvider.jsonld' } } } }
       summary: 'Retrieves the collection of Organization resources.'
       description: 'Retrieves the collection of Organization resources.'
       parameters:
@@ -1395,28 +1244,24 @@ paths:
           description: 'The collection page number'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 1
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: itemsPerPage
           in: query
           description: 'The number of items per page'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 20
             minimum: 0
             maximum: 100
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: name
           in: query
@@ -1435,73 +1280,60 @@ paths:
           description: 'Filter based on updated greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00" (DEPRECATED - please use a filter with an explicit operator, e.g. updated[gt]=2004-02-12T15:19:21+00:00) '
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[between]'
           in: query
           description: "Filter based on updated between two ISO 8601 datetime [(yyyy-MM-dd'T'HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns) seperated by '..', e.g. \"2004-02-12T15:19:21+00:00..2004-02-13T16:20:22+00:00\""
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[gt]'
           in: query
           description: 'Filter based on updated greater than ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[gte]'
           in: query
           description: 'Filter based on updated greater then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[lt]'
           in: query
           description: 'Filter based on updated less then ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
         -
           name: 'updated[lte]'
           in: query
           description: 'Filter based on updated less then or equal to ISO 8601 datetime [(yyyy-MM-dd''T''HH:mm:ssz)](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/time/format/DateTimeFormatter.html#patterns), e.g. "2004-02-12T15:19:21+00:00"'
           required: false
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: form
           explode: false
-          allowReserved: false
-      deprecated: false
   '/api/v2/organizations/{id}':
     get:
       operationId: api_organizations_id_get
@@ -1510,6 +1342,10 @@ paths:
       responses:
         '200':
           description: 'Single organization'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Organization.OrganizationRepresentationProvider.jsonld'
         '404':
           description: 'Not found'
           content:
@@ -1524,21 +1360,18 @@ paths:
                 $ref: '#/components/schemas/Error'
           links: {  }
       summary: 'Get single organization based on identifier'
-      description: 'Retrieves a Organization resource.'
+      description: 'Get single organization based on identifier'
       parameters:
         -
           name: id
           in: path
-          description: ''
+          description: 'Organization identifier'
           required: true
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: integer
           style: simple
           explode: false
-          allowReserved: false
-      deprecated: false
   /api/v2/tags:
     get:
       operationId: api_tags_get_collection
@@ -1551,13 +1384,10 @@ paths:
             application/ld+json:
               schema:
                 type: object
-                properties:
-                  'hydra:member': { type: array, items: { $ref: '#/components/schemas/Tag.jsonld' } }
-                  'hydra:totalItems': { type: integer, minimum: 0 }
-                  'hydra:view': { type: object, properties: { '@id': { type: string, format: iri-reference }, '@type': { type: string }, 'hydra:first': { type: string, format: iri-reference }, 'hydra:last': { type: string, format: iri-reference }, 'hydra:previous': { type: string, format: iri-reference }, 'hydra:next': { type: string, format: iri-reference } }, example: { '@id': string, type: string, 'hydra:first': string, 'hydra:last': string, 'hydra:previous': string, 'hydra:next': string } }
-                  'hydra:search': { type: object, properties: { '@type': { type: string }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string }, 'hydra:mapping': { type: array, items: { type: object, properties: { '@type': { type: string }, variable: { type: string }, property: { type: [string, 'null'] }, required: { type: boolean } } } } } }
-                required:
-                  - 'hydra:member'
+                description: 'Tag.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: ['hydra:member'], properties: { 'hydra:member': { type: array, items: { $ref: '#/components/schemas/Tag.jsonld' } } } }
       summary: 'Retrieves the collection of Tag resources.'
       description: 'Retrieves the collection of Tag resources.'
       parameters:
@@ -1567,28 +1397,24 @@ paths:
           description: 'The collection page number'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 1
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: itemsPerPage
           in: query
           description: 'The number of items per page'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 20
             minimum: 0
             maximum: 100
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: name
           in: query
@@ -1613,7 +1439,6 @@ paths:
           style: form
           explode: false
           allowReserved: false
-      deprecated: false
   '/api/v2/tags/{slug}':
     get:
       operationId: api_tags_slug_get
@@ -1622,6 +1447,10 @@ paths:
       responses:
         '200':
           description: 'Get single tag'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Tag.jsonld'
         '404':
           description: 'Not found'
           content:
@@ -1636,21 +1465,18 @@ paths:
                 $ref: '#/components/schemas/Error'
           links: {  }
       summary: 'Get single tag'
-      description: 'Retrieves a Tag resource.'
+      description: 'Get single tag'
       parameters:
         -
           name: slug
           in: path
-          description: ''
+          description: 'Tag identifier'
           required: true
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: simple
           explode: false
-          allowReserved: false
-      deprecated: false
   /api/v2/vocabularies:
     get:
       operationId: api_vocabularies_get_collection
@@ -1663,13 +1489,10 @@ paths:
             application/ld+json:
               schema:
                 type: object
-                properties:
-                  'hydra:member': { type: array, items: { $ref: '#/components/schemas/Vocabulary.jsonld' } }
-                  'hydra:totalItems': { type: integer, minimum: 0 }
-                  'hydra:view': { type: object, properties: { '@id': { type: string, format: iri-reference }, '@type': { type: string }, 'hydra:first': { type: string, format: iri-reference }, 'hydra:last': { type: string, format: iri-reference }, 'hydra:previous': { type: string, format: iri-reference }, 'hydra:next': { type: string, format: iri-reference } }, example: { '@id': string, type: string, 'hydra:first': string, 'hydra:last': string, 'hydra:previous': string, 'hydra:next': string } }
-                  'hydra:search': { type: object, properties: { '@type': { type: string }, 'hydra:template': { type: string }, 'hydra:variableRepresentation': { type: string }, 'hydra:mapping': { type: array, items: { type: object, properties: { '@type': { type: string }, variable: { type: string }, property: { type: [string, 'null'] }, required: { type: boolean } } } } } }
-                required:
-                  - 'hydra:member'
+                description: 'Vocabulary.jsonld collection.'
+                allOf:
+                  - { $ref: '#/components/schemas/HydraCollectionBaseSchema' }
+                  - { type: object, required: ['hydra:member'], properties: { 'hydra:member': { type: array, items: { $ref: '#/components/schemas/Vocabulary.jsonld' } } } }
       summary: 'Retrieves the collection of Vocabulary resources.'
       description: 'Retrieves the collection of Vocabulary resources.'
       parameters:
@@ -1679,28 +1502,24 @@ paths:
           description: 'The collection page number'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 1
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: itemsPerPage
           in: query
           description: 'The number of items per page'
           required: false
           deprecated: false
-          allowEmptyValue: true
           schema:
             type: integer
             default: 20
             minimum: 0
             maximum: 100
           style: form
-          explode: false
-          allowReserved: false
+          explode: true
         -
           name: name
           in: query
@@ -1725,7 +1544,6 @@ paths:
           style: form
           explode: false
           allowReserved: false
-      deprecated: false
   '/api/v2/vocabularies/{slug}':
     get:
       operationId: api_vocabularies_slug_get
@@ -1734,6 +1552,10 @@ paths:
       responses:
         '200':
           description: 'Get single vocabulary'
+          content:
+            application/ld+json:
+              schema:
+                $ref: '#/components/schemas/Vocabulary.jsonld'
         '404':
           description: 'Not found'
           content:
@@ -1748,66 +1570,46 @@ paths:
                 $ref: '#/components/schemas/Error'
           links: {  }
       summary: 'Get a vocabulary based on slug'
-      description: 'Retrieves a Vocabulary resource.'
+      description: 'Get a vocabulary based on slug'
       parameters:
         -
           name: slug
           in: path
-          description: ''
+          description: 'Vocabulary identifier'
           required: true
           deprecated: false
-          allowEmptyValue: false
           schema:
             type: string
           style: simple
           explode: false
-          allowReserved: false
-      deprecated: false
 components:
   schemas:
     DailyOccurrence.DailyOccurrenceRepresentationProvider.jsonld:
-      type: object
-      description: ''
-      deprecated: false
-      properties:
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
-        '@context':
-          readOnly: true
-          oneOf:
-            -
-              type: string
-            -
-              type: object
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  type: string
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-              required:
-                - '@vocab'
-                - hydra
-              additionalProperties: true
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
     Error:
       type: object
       description: 'A representation of common errors.'
-      deprecated: false
       properties:
         title:
           readOnly: true
           description: 'A short, human-readable summary of the problem.'
-          type: string
+          type:
+            - string
+            - 'null'
         detail:
           readOnly: true
           description: 'A human-readable explanation specific to this occurrence of the problem.'
-          type: string
+          type:
+            - string
+            - 'null'
         status:
-          type: number
+          type:
+            - integer
+            - 'null'
           examples:
             - 404
           default: 400
@@ -1822,74 +1624,115 @@ components:
           description: 'A URI reference that identifies the problem type'
           type: string
     Error.jsonld:
-      type: object
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
+          properties:
+            title:
+              readOnly: true
+              description: 'A short, human-readable summary of the problem.'
+              type:
+                - string
+                - 'null'
+            detail:
+              readOnly: true
+              description: 'A human-readable explanation specific to this occurrence of the problem.'
+              type:
+                - string
+                - 'null'
+            status:
+              type:
+                - integer
+                - 'null'
+              examples:
+                - 404
+              default: 400
+            instance:
+              readOnly: true
+              description: 'A URI reference that identifies the specific occurrence of the problem. It may or may not yield further information if dereferenced.'
+              type:
+                - string
+                - 'null'
+            type:
+              readOnly: true
+              description: 'A URI reference that identifies the problem type'
+              type: string
+            description:
+              readOnly: true
+              type:
+                - string
+                - 'null'
       description: 'A representation of common errors.'
-      deprecated: false
-      properties:
-        '@context':
-          readOnly: true
-          oneOf:
-            -
-              type: string
-            -
-              type: object
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  type: string
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-              required:
-                - '@vocab'
-                - hydra
-              additionalProperties: true
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
-        title:
-          readOnly: true
-          description: 'A short, human-readable summary of the problem.'
-          type: string
-        detail:
-          readOnly: true
-          description: 'A human-readable explanation specific to this occurrence of the problem.'
-          type: string
-        status:
-          type: number
-          examples:
-            - 404
-          default: 400
-        instance:
-          readOnly: true
-          description: 'A URI reference that identifies the specific occurrence of the problem. It may or may not yield further information if dereferenced.'
-          type:
-            - string
-            - 'null'
-        type:
-          readOnly: true
-          description: 'A URI reference that identifies the problem type'
-          type: string
-        description:
-          readOnly: true
-          type:
-            - string
-            - 'null'
     Event.EventRepresentationProvider.jsonld:
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
+    HydraCollectionBaseSchema:
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraCollectionBaseSchemaNoPagination'
+        -
+          type: object
+          properties:
+            'hydra:view':
+              type: object
+              properties:
+                '@id':
+                  type: string
+                  format: iri-reference
+                '@type':
+                  type: string
+                'hydra:first':
+                  type: [string, 'null']
+                  format: iri-reference
+                'hydra:last':
+                  type: [string, 'null']
+                  format: iri-reference
+                'hydra:previous':
+                  type: [string, 'null']
+                  format: iri-reference
+                'hydra:next':
+                  type: [string, 'null']
+                  format: iri-reference
+              example:
+                '@id': string
+                '@type': string
+                'hydra:first': string
+                'hydra:last': string
+                'hydra:previous': string
+                'hydra:next': string
+    HydraCollectionBaseSchemaNoPagination:
       type: object
-      description: ''
-      deprecated: false
       properties:
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
+        'hydra:totalItems':
+          type: integer
+          minimum: 0
+        'hydra:search':
+          type: object
+          properties:
+            '@type':
+              type: string
+            'hydra:template':
+              type: string
+            'hydra:variableRepresentation':
+              type: string
+            'hydra:mapping':
+              type: array
+              items:
+                type: object
+                properties:
+                  '@type': { type: string }
+                  variable: { type: string }
+                  property: { type: [string, 'null'] }
+                  required: { type: boolean }
+    HydraItemBaseSchema:
+      type: object
+      properties:
         '@context':
-          readOnly: true
           oneOf:
             -
               type: string
@@ -1905,160 +1748,61 @@ components:
                 - '@vocab'
                 - hydra
               additionalProperties: true
+        '@id':
+          type: string
+        '@type':
+          type: string
+      required:
+        - '@id'
+        - '@type'
     Location.LocationRepresentationProvider.jsonld:
-      type: object
-      description: ''
-      deprecated: false
-      properties:
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
-        '@context':
-          readOnly: true
-          oneOf:
-            -
-              type: string
-            -
-              type: object
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  type: string
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-              required:
-                - '@vocab'
-                - hydra
-              additionalProperties: true
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
     Occurrence.OccurrenceRepresentationProvider.jsonld:
-      type: object
-      description: ''
-      deprecated: false
-      properties:
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
-        '@context':
-          readOnly: true
-          oneOf:
-            -
-              type: string
-            -
-              type: object
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  type: string
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-              required:
-                - '@vocab'
-                - hydra
-              additionalProperties: true
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
     Organization.OrganizationRepresentationProvider.jsonld:
-      type: object
-      description: ''
-      deprecated: false
-      properties:
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
-        '@context':
-          readOnly: true
-          oneOf:
-            -
-              type: string
-            -
-              type: object
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  type: string
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-              required:
-                - '@vocab'
-                - hydra
-              additionalProperties: true
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
     Tag.jsonld:
-      type: object
-      description: ''
-      deprecated: false
-      properties:
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
-        '@context':
-          readOnly: true
-          oneOf:
-            -
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
+          properties:
+            slug:
               type: string
-            -
-              type: object
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  type: string
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-              required:
-                - '@vocab'
-                - hydra
-              additionalProperties: true
-        slug:
-          type: string
-        name:
-          type: string
+            name:
+              type: string
     Vocabulary.jsonld:
-      type: object
-      description: ''
-      deprecated: false
-      properties:
-        '@id':
-          readOnly: true
-          type: string
-        '@type':
-          readOnly: true
-          type: string
-        '@context':
-          readOnly: true
-          oneOf:
-            -
+      allOf:
+        -
+          $ref: '#/components/schemas/HydraItemBaseSchema'
+        -
+          type: object
+          properties:
+            slug:
               type: string
-            -
-              type: object
-              properties:
-                '@vocab':
-                  type: string
-                hydra:
-                  type: string
-                  enum: ['http://www.w3.org/ns/hydra/core#']
-              required:
-                - '@vocab'
-                - hydra
-              additionalProperties: true
-        slug:
-          type: string
-        name:
-          type: string
-        description:
-          type: string
-        tags:
-          type: array
-          items:
-            type: string
+            name:
+              type: string
+            description:
+              type: string
+            tags:
+              type: array
+              items:
+                type:
+                  - string
+                  - 'null'
   responses: {  }
   parameters: {  }
   examples: {  }
@@ -2076,16 +1820,23 @@ security:
 tags:
   -
     name: DailyOccurrence
+    description: "Resource 'DailyOccurrence' operations."
   -
     name: Event
+    description: "Resource 'Event' operations."
   -
     name: Location
+    description: "Resource 'Location' operations."
   -
     name: Occurrence
+    description: "Resource 'Occurrence' operations."
   -
     name: Organization
+    description: "Resource 'Organization' operations."
   -
     name: Tag
+    description: "Resource 'Tag' operations."
   -
     name: Vocabulary
+    description: "Resource 'Vocabulary' operations."
 webhooks: {  }

--- a/tests/ApiPlatform/AbstractApiTestCase.php
+++ b/tests/ApiPlatform/AbstractApiTestCase.php
@@ -18,6 +18,17 @@ abstract class AbstractApiTestCase extends ApiTestCase
 
     protected static int|string $unknownItemId = 99999;
 
+    /**
+     * Whether to assert the collection against API Platform's self-generated
+     * JSON schema. That schema requires `@id`/`@var` on every member; the five
+     * resources whose provider returns the raw Elasticsearch `_source` (Event,
+     * Occurrence, DailyOccurrence, Location, Organization) intentionally omit
+     * those (see README "Known limitations", D6), so they opt out. Tag and
+     * Vocabulary are true API Platform resources and keep the assertion — where
+     * it also serves as a tripwire for future API Platform upgrades.
+     */
+    protected static bool $assertsGeneratedCollectionSchema = true;
+
     protected static function createAuthenticatedClient(): Client
     {
         return static::createClient(defaultOptions: [

--- a/tests/ApiPlatform/Contract/ErrorContractTest.php
+++ b/tests/ApiPlatform/Contract/ErrorContractTest.php
@@ -8,7 +8,12 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Locks the error-response contract. API Platform has changed error
  * serialization across versions (hydra:Error vs problem+json, field names), so
- * the exact shape of 401/404 is worth pinning before the upgrade.
+ * the exact shape of 401/404 is worth pinning.
+ *
+ * Under API Platform 4.3 (with `hydra_prefix: true`) the human-readable fields
+ * are hydra-prefixed — `hydra:title` / `hydra:description` — while the
+ * machine-readable `status`, `type` and `detail` are unprefixed. (In 4.1 the
+ * title was emitted unprefixed as `title`.)
  *
  * Note: the body also carries a `trace` array in the test env (debug on); that
  * is environment-dependent and intentionally NOT asserted here.
@@ -29,8 +34,10 @@ class ErrorContractTest extends AbstractApiTestCase
         $this->assertSame('hydra:Error', $data['@type']);
         $this->assertSame(401, $data['status']);
         $this->assertSame('/errors/401', $data['type']);
-        $this->assertArrayHasKey('title', $data);
         $this->assertArrayHasKey('detail', $data);
+        // 4.3 hydra-prefixes the human-readable fields (was unprefixed `title` in 4.1).
+        $this->assertArrayHasKey('hydra:title', $data);
+        $this->assertArrayHasKey('hydra:description', $data);
     }
 
     public function testNotFoundErrorShape(): void

--- a/tests/ApiPlatform/DailyOccurrencesTest.php
+++ b/tests/ApiPlatform/DailyOccurrencesTest.php
@@ -15,5 +15,9 @@ class DailyOccurrencesTest extends AbstractApiTestCase
 
     protected static string $resourceClass = DailyOccurrence::class;
 
+    // Members are the raw Elasticsearch _source with no @id/@type, so API
+    // Platform's self-generated collection schema does not apply (see D6).
+    protected static bool $assertsGeneratedCollectionSchema = false;
+
     protected static int|string $itemId = 10;
 }

--- a/tests/ApiPlatform/EventsTest.php
+++ b/tests/ApiPlatform/EventsTest.php
@@ -18,5 +18,9 @@ class EventsTest extends AbstractApiTestCase
 
     protected static string $resourceClass = Event::class;
 
+    // Members are the raw Elasticsearch _source with no @id/@type, so API
+    // Platform's self-generated collection schema does not apply (see D6).
+    protected static bool $assertsGeneratedCollectionSchema = false;
+
     protected static int|string $itemId = 7;
 }

--- a/tests/ApiPlatform/LocationsTest.php
+++ b/tests/ApiPlatform/LocationsTest.php
@@ -15,5 +15,9 @@ class LocationsTest extends AbstractApiTestCase
 
     protected static string $resourceClass = Location::class;
 
+    // Members are the raw Elasticsearch _source with no @id/@type, so API
+    // Platform's self-generated collection schema does not apply (see D6).
+    protected static bool $assertsGeneratedCollectionSchema = false;
+
     protected static int|string $itemId = 4;
 }

--- a/tests/ApiPlatform/OccurrencesTest.php
+++ b/tests/ApiPlatform/OccurrencesTest.php
@@ -15,5 +15,9 @@ class OccurrencesTest extends AbstractApiTestCase
 
     protected static string $resourceClass = Occurrence::class;
 
+    // Members are the raw Elasticsearch _source with no @id/@type, so API
+    // Platform's self-generated collection schema does not apply (see D6).
+    protected static bool $assertsGeneratedCollectionSchema = false;
+
     protected static int|string $itemId = 10;
 }

--- a/tests/ApiPlatform/OrganizationsTest.php
+++ b/tests/ApiPlatform/OrganizationsTest.php
@@ -15,5 +15,9 @@ class OrganizationsTest extends AbstractApiTestCase
 
     protected static string $resourceClass = Organization::class;
 
+    // Members are the raw Elasticsearch _source with no @id/@type, so API
+    // Platform's self-generated collection schema does not apply (see D6).
+    protected static bool $assertsGeneratedCollectionSchema = false;
+
     protected static int|string $itemId = 9;
 }

--- a/tests/ApiPlatform/Trait/GetEntitiesTestTrait.php
+++ b/tests/ApiPlatform/Trait/GetEntitiesTestTrait.php
@@ -24,7 +24,7 @@ trait GetEntitiesTestTrait
         $this->assertArrayHasKey('hydra:member', $data);
         $this->assertArrayHasKey('hydra:totalItems', $data);
 
-        if (isset(static::$resourceClass)) {
+        if (isset(static::$resourceClass) && static::$assertsGeneratedCollectionSchema) {
             $this->assertMatchesResourceCollectionJsonSchema(static::$resourceClass);
         }
     }


### PR DESCRIPTION
Bumps API Platform to the latest 4.x — the upgrade the recent test/contract-hardening work (#35–#45) was preparing for.

## Changes

- `composer.json`: `api-platform/core` pin `~4.1.0` → `~4.3.0` (resolves to 4.3.16; pulls symfony/serializer + validator patch bumps within 7.4).
- Regenerate `public/spec.yaml` and `config/reference.php`.
- `ErrorContractTest`: pin the 4.3 hydra error shape (`hydra:title`/`hydra:description`).
- Exempt the five raw-`_source` resources from API Platform's self-generated collection-schema assertion via `$assertsGeneratedCollectionSchema` (they carry no `@id`/`@type` — D6); Tag/Vocabulary keep it.

## Runtime impact: backwards-compatible

Full suite green (237 tests), including the hand-authored `CollectionContractTest` / `ItemContractTest` / `ContractSchemaTest` — response payloads are byte-identical, **except one error-body change**:

- **401/404 error bodies** now use `hydra:title` + `hydra:description` instead of the unprefixed `title` (4.3 behaviour under `hydra_prefix: true`, consistent with the rest of the hydra-prefixed API). The machine-readable `status`, `type` and `detail` are unchanged.

## Expected: the api-spec "breaking changes" check is red

4.3 changed OpenAPI **spec generation** — collection schemas now use `allOf` + a shared `HydraCollectionBaseSchema`, and error schemas widened (nullable/`any`). `oasdiff` reads these as ~70 breaking spec changes, but they are representation-level: the runtime responses are unchanged (verified by the contract suite). The check is informational (not a required check); the 🛑 comment documents the spec delta for reviewers.

## Not included (deliberately)

- **Symfony 8** — major upgrade, needs PHP 8.4 floor; 7.4 is LTS. Separate effort.
- **elasticsearch/elasticsearch 9.x** — client major must match the 8.x cluster; cross-repo/infra decision.