### PR TITLE
Bump oasdiff-action to v0.1.5

### DIFF
--- a/.github/workflows/api-spec.yml
+++ b/.github/workflows/api-spec.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Detect breaking changes
         id: breaking
         continue-on-error: true
-        uses: oasdiff/oasdiff-action/breaking@v0.0.44
+        uses: oasdiff/oasdiff-action/breaking@v0.1.5
         with:
           base: .api-spec-tmp/base.yaml
           revision: .api-spec-tmp/revision.yaml
@@ -102,7 +102,7 @@ jobs:
       - name: Generate changelog
         id: changelog
         continue-on-error: true
-        uses: oasdiff/oasdiff-action/changelog@v0.0.44
+        uses: oasdiff/oasdiff-action/changelog@v0.1.5
         with:
           base: .api-spec-tmp/base.yaml
           revision: .api-spec-tmp/revision.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-49](https://github.com/itk-dev/event-database-api/pull/49)
+  Bump oasdiff-action to v0.1.5 in the API-spec workflow
 - [PR-48](https://github.com/itk-dev/event-database-api/pull/48)
   Add an os2display consumer contract test suite exercising the endpoints and filters its feed helper depends on
 - [PR-47](https://github.com/itk-dev/event-database-api/pull/47)


### PR DESCRIPTION
Updates the API-spec workflow's oasdiff steps from v0.0.44 to the latest release, v0.1.5.

## Changes

- `.github/workflows/api-spec.yml`: `oasdiff/oasdiff-action/breaking` and `.../changelog` `@v0.0.44` → `@v0.1.5`.

## Why

Keep the action current. The bump is **input-compatible** (the `base`, `revision`, `fail-on`, `format`, `output-to-file` inputs the workflow uses all still exist) and **behaviour-neutral** (the workflow keeps `fail-on: ERR`, and `flatten-allof` defaults to `false` in both versions), so the gate's result does not change.

v0.1.5 additionally exposes `flatten-allof` and `err-ignore`/`warn-ignore` inputs — the knobs discussed for reducing the API-spec gate's allOf/error-schema noise. This PR does **not** enable them; it only bumps the version, leaving that decision separate.