### PR TITLE
Disable oasdiff.com spec upload (review: false)

### DIFF
--- a/.github/workflows/api-spec.yml
+++ b/.github/workflows/api-spec.yml
@@ -98,6 +98,8 @@ jobs:
           base: .api-spec-tmp/base.yaml
           revision: .api-spec-tmp/revision.yaml
           fail-on: ERR
+          # Do not upload the spec to oasdiff.com; keep the diff entirely in CI.
+          review: false
 
       - name: Generate changelog
         id: changelog
@@ -108,6 +110,8 @@ jobs:
           revision: .api-spec-tmp/revision.yaml
           format: markdown
           output-to-file: changelog.md
+          # Do not upload the spec to oasdiff.com; keep the diff entirely in CI.
+          review: false
 
       - name: Determine whether the spec changed
         id: changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-50](https://github.com/itk-dev/event-database-api/pull/50)
+  Disable the oasdiff.com spec upload (review: false) so no API spec leaves CI
 - [PR-49](https://github.com/itk-dev/event-database-api/pull/49)
   Bump oasdiff-action to v0.1.5 in the API-spec workflow
 - [PR-48](https://github.com/itk-dev/event-database-api/pull/48)


### PR DESCRIPTION
Turn off the external spec upload that oasdiff-action v0.1.5 enabled by default.

## Changes

- `.github/workflows/api-spec.yml`: add `review: false` to both the `breaking` and `changelog` oasdiff steps.

## Why

v0.1.5 introduced a new `review` input defaulting to `true` (it did not exist in v0.0.44). With it on, the action uploads `public/spec.yaml` to oasdiff.com on every spec-diffing run and posts a hosted side-by-side "review" comment. The spec is public and the upload is client-side encrypted, but sending the API surface to a third-party SaaS by default is a data-governance choice we should make deliberately — not inherit from a version bump (introduced in #49).

`review: false` skips the upload entirely; per the action's own docs the local change detection, the `fail-on: ERR` breaking-change gate, and the committed-spec check are all unaffected.