### PR TITLE
Show the API-spec diff summary inline in the PR comment

### DIFF
--- a/.github/workflows/api-spec.yml
+++ b/.github/workflows/api-spec.yml
@@ -98,6 +98,11 @@ jobs:
           base: .api-spec-tmp/base.yaml
           revision: .api-spec-tmp/revision.yaml
           fail-on: ERR
+          # Upload to oasdiff.com to get a side-by-side review link (exposed as
+          # the review_url output), but suppress the action's own comment with an
+          # empty token — we post a single combined comment below.
+          review: true
+          github-token: ""
 
       - name: Generate changelog
         id: changelog
@@ -108,6 +113,9 @@ jobs:
           revision: .api-spec-tmp/revision.yaml
           format: markdown
           output-to-file: changelog.md
+          # As above: keep the upload/review_url output, suppress the auto-comment.
+          review: true
+          github-token: ""
 
       - name: Determine whether the spec changed
         id: changes
@@ -135,12 +143,20 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PREV_ID: ${{ steps.prev-comment.outputs.id }}
+          REVIEW_URL: ${{ steps.changelog.outputs.review_url }}
         run: |
           {
             echo "<!-- api-spec-workflow -->"
             echo "## ⚠️ API specification — non-breaking changes"
             echo ""
+            echo "<details><summary>API changes</summary>"
+            echo ""
             cat changelog.md
+            echo ""
+            echo "</details>"
+            if [ -n "$REVIEW_URL" ]; then
+              printf '\n🔍 [View the full side-by-side review](%s)\n' "$REVIEW_URL"
+            fi
           } > comment.md
           if [ -n "$PREV_ID" ]; then
             jq -Rs '{body: .}' < comment.md \
@@ -154,15 +170,23 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PREV_ID: ${{ steps.prev-comment.outputs.id }}
+          REVIEW_URL: ${{ steps.breaking.outputs.review_url }}
         run: |
           {
             echo "<!-- api-spec-workflow -->"
             echo "## 🛑 API specification — breaking changes detected"
             echo ""
             if [ -s changelog.md ]; then
+              echo "<details><summary>API changes</summary>"
+              echo ""
               cat changelog.md
+              echo ""
+              echo "</details>"
             else
               echo "The breaking-changes check flagged incompatible changes. Review the workflow logs for details."
+            fi
+            if [ -n "$REVIEW_URL" ]; then
+              printf '\n🔍 [View the full side-by-side review](%s)\n' "$REVIEW_URL"
             fi
           } > comment.md
           if [ -n "$PREV_ID" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-51](https://github.com/itk-dev/event-database-api/pull/51)
+  Show the API-spec diff summary inline in the PR comment (collapsed) alongside the oasdiff review link
 - [PR-49](https://github.com/itk-dev/event-database-api/pull/49)
   Bump oasdiff-action to v0.1.5 in the API-spec workflow
 - [PR-48](https://github.com/itk-dev/event-database-api/pull/48)


### PR DESCRIPTION
Supersedes #50. Instead of disabling the oasdiff.com upload, keep it — but stop making reviewers click through to see the diff.

## Changes

- Both oasdiff steps: keep `review: true` (upload + `review_url` output) and set `github-token: ""` to suppress the action's own standalone link-only comment.
- The workflow's existing sticky comment now renders the changelog **inline in a collapsed `<details>`** and appends a **`🔍 View the full side-by-side review`** link (from `steps.{breaking,changelog}.outputs.review_url`).

Net result per PR (Codecov-style, one comment):
- **Non-breaking** → ⚠️ headline + collapsed `API changes` summary + review link.
- **Breaking** → 🛑 headline + collapsed summary + review link.
- **No changes** → ✅ resolved (no link; the action returns an empty `review_url` when there's nothing to review).

## Why

`oasdiff-action` v0.1.5 (#49) posts a link-only comment by default, so the actual diff lived only on oasdiff.com. This keeps the hosted side-by-side review available but surfaces the summary directly on the PR, so you don't have to leave GitHub for the common case. The upload behaviour is unchanged (the spec is public); only *where the diff is shown* changes.

Note: the API-spec workflow is path-filtered to spec-affecting paths, so the new comment first renders on the next PR that changes `src`/`config`/`spec` (e.g. #46 once it picks this up).