### PR TITLE
Pin the problem+json error/negotiation contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-52](https://github.com/itk-dev/event-database-api/pull/52)
+  Pin the problem+json error contract: 401 served as RFC 7807, resource reads in problem+json yield 406
 - [PR-51](https://github.com/itk-dev/event-database-api/pull/51)
   Show the API-spec diff summary inline in the PR comment (collapsed) alongside the oasdiff review link
 - [PR-49](https://github.com/itk-dev/event-database-api/pull/49)

--- a/tests/ApiPlatform/Contract/ErrorContractTest.php
+++ b/tests/ApiPlatform/Contract/ErrorContractTest.php
@@ -52,4 +52,51 @@ class ErrorContractTest extends AbstractApiTestCase
         $this->assertSame(404, $data['status']);
         $this->assertSame('/errors/404', $data['type']);
     }
+
+    /**
+     * When a client asks for problem+json, auth errors are served as RFC 7807
+     * problem+json (unprefixed title/detail/status/type) rather than hydra.
+     * The 401 short-circuits before resource content negotiation, so it is
+     * available in the requested media type.
+     */
+    public function testUnauthenticatedErrorIsAvailableAsProblemJson(): void
+    {
+        $client = self::createClient(defaultOptions: [
+            'headers' => ['accept' => ['application/problem+json']],
+        ]);
+        $response = $client->request('GET', '/api/v2/events');
+
+        $this->assertSame(Response::HTTP_UNAUTHORIZED, $response->getStatusCode());
+        $this->assertStringContainsString('application/problem+json', $response->getHeaders(false)['content-type'][0] ?? '');
+
+        $data = $response->toArray(false);
+        $this->assertSame(401, $data['status']);
+        $this->assertSame('/errors/401', $data['type']);
+        $this->assertArrayHasKey('title', $data);
+        $this->assertArrayHasKey('detail', $data);
+    }
+
+    /**
+     * The resources themselves only produce ld+json, so requesting an item with
+     * `Accept: application/problem+json` is not satisfiable — it yields 406 Not
+     * Acceptable (NOT a 404), and the 406 body is itself a problem+json error.
+     * Pinning this documents that problem+json is not a resource representation;
+     * consumers must read resources as ld+json.
+     */
+    public function testProblemJsonIsNotAcceptableForResourceReads(): void
+    {
+        $client = self::createClient(defaultOptions: [
+            'headers' => [
+                'accept' => ['application/problem+json'],
+                'x-api-key' => 'test_api_key',
+            ],
+        ]);
+        $response = $client->request('GET', '/api/v2/events/99999');
+
+        $this->assertSame(Response::HTTP_NOT_ACCEPTABLE, $response->getStatusCode());
+        $this->assertStringContainsString('application/problem+json', $response->getHeaders(false)['content-type'][0] ?? '');
+
+        $data = $response->toArray(false);
+        $this->assertSame(406, $data['status']);
+    }
 }

--- a/tests/ApiPlatform/Contract/ErrorContractTest.php
+++ b/tests/ApiPlatform/Contract/ErrorContractTest.php
@@ -54,10 +54,13 @@ class ErrorContractTest extends AbstractApiTestCase
     }
 
     /**
-     * When a client asks for problem+json, auth errors are served as RFC 7807
-     * problem+json (unprefixed title/detail/status/type) rather than hydra.
-     * The 401 short-circuits before resource content negotiation, so it is
-     * available in the requested media type.
+     * `rfc_7807_compliant_errors: true` (config/packages/api_platform.yaml)
+     * registers problem+json as an error format, so an auth error requested as
+     * `application/problem+json` is served as RFC 7807 (unprefixed
+     * title/detail/status/type) rather than hydra. The 401 also short-circuits
+     * before resource content negotiation, so the format is honoured.
+     *
+     * @see https://api-platform.com/docs/core/content-negotiation/
      */
     public function testUnauthenticatedErrorIsAvailableAsProblemJson(): void
     {
@@ -77,11 +80,15 @@ class ErrorContractTest extends AbstractApiTestCase
     }
 
     /**
-     * The resources themselves only produce ld+json, so requesting an item with
-     * `Accept: application/problem+json` is not satisfiable — it yields 406 Not
-     * Acceptable (NOT a 404), and the 406 body is itself a problem+json error.
-     * Pinning this documents that problem+json is not a resource representation;
-     * consumers must read resources as ld+json.
+     * The only resource format configured under `formats` in
+     * config/packages/api_platform.yaml is `application/ld+json`, so content
+     * negotiation cannot satisfy `Accept: application/problem+json` on a resource
+     * read: it yields 406 Not Acceptable (NOT a 404), and the 406 body is itself
+     * a problem+json error. Pinning this documents that problem+json is not a
+     * resource representation (consumers must read resources as ld+json) and
+     * guards the `formats` allow-list — adding problem+json there would flip this.
+     *
+     * @see https://api-platform.com/docs/core/content-negotiation/
      */
     public function testProblemJsonIsNotAcceptableForResourceReads(): void
     {


### PR DESCRIPTION
Closes the last untested corner of the error contract: what the API does when a client asks for `application/problem+json`.

## Changes

Two new `ErrorContractTest` cases (verified against the running 4.3 API):

- **Auth error as problem+json** — `GET /api/v2/events` (unauthenticated) with `Accept: application/problem+json` → **401**, `content-type: application/problem+json`, RFC 7807 fields (`title`, `detail`, `status`, `type`). The 401 short-circuits before resource negotiation, so it is served in the requested media type.
- **problem+json not acceptable for resource reads** — `GET /api/v2/events/{id}` with `Accept: application/problem+json` → **406 Not Acceptable** (the resources only produce `ld+json`), and the 406 body is itself a problem+json error.

## Why

The regenerated 4.3 spec documents `application/problem+json`/`application/json` media types on error responses, but nothing tested whether the API actually serves them. This pins the real behaviour: problem+json is available for errors that precede resource negotiation (401), but is **not** a resource representation — asking for it on a resource yields 406, not the resource and not a 404. Consumers must read resources as `ld+json`. Tests only.