### PR TITLE
Compare effective schemas in oasdiff (flatten-allof)

### DIFF
--- a/.github/workflows/api-spec.yml
+++ b/.github/workflows/api-spec.yml
@@ -98,6 +98,9 @@ jobs:
           base: .api-spec-tmp/base.yaml
           revision: .api-spec-tmp/revision.yaml
           fail-on: ERR
+          # Compare effective (flattened) schemas so an allOf/$ref restructure is
+          # not reported as removed properties. Never masks real diffs.
+          flatten-allof: true
           # Upload to oasdiff.com to get a side-by-side review link (exposed as
           # the review_url output), but suppress the action's own comment with an
           # empty token — we post a single combined comment below.
@@ -113,6 +116,7 @@ jobs:
           revision: .api-spec-tmp/revision.yaml
           format: markdown
           output-to-file: changelog.md
+          flatten-allof: true
           # As above: keep the upload/review_url output, suppress the auto-comment.
           review: true
           github-token: ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-53](https://github.com/itk-dev/event-database-api/pull/53)
+  Compare effective schemas in the oasdiff gate (flatten-allof) so allOf/$ref restructures are not miscounted
 - [PR-51](https://github.com/itk-dev/event-database-api/pull/51)
   Show the API-spec diff summary inline in the PR comment (collapsed) alongside the oasdiff review link
 - [PR-49](https://github.com/itk-dev/event-database-api/pull/49)


### PR DESCRIPTION
Enables `flatten-allof: true` on both oasdiff steps in the API-spec workflow.

## Changes

- `.github/workflows/api-spec.yml`: add `flatten-allof: true` to the `breaking` and `changelog` steps.

## Why — and an honest note on scope

`flatten-allof` compares the **effective** (flattened) schema, so an `allOf`/`$ref` restructure isn't misreported as removed properties. This is the class of noise the 4.1→4.3 upgrade produced (7× "removed required `hydra:member`" etc. from the new `HydraCollectionBaseSchema`).

I verified empirically against the real 4.1→4.3 spec diff:

| | errors | warnings |
|---|---|---|
| without flatten | 70 | 84 |
| **with flatten** | **113** | **0** |

So it does eliminate the ~98 allOf artifacts — but it does **not** reduce the gate to near-zero: the 4.1→4.3 **error-schema widenings** (nullable/type changes) remain and even expand once the effective schemas are compared field-by-field. Those are real, and that entire diff is a **merged one-off** — going forward every comparison is 4.3-vs-4.3, so the allOf-mismatch class can't recur regardless of this flag.

Net: this is **forward-looking hygiene** (robustness against future API Platform schema restructures), not a fix for a present problem. It's low-risk — `flatten-allof` never masks a real breaking change; it only changes how structurally-refactored-but-equivalent schemas are compared.