### PR TITLE
Add Rector (relevant sets, aligned with PHPStan) and apply across the codebase

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,3 +68,27 @@ jobs:
       - name: Run code analysis
         run: |
           docker compose exec -T phpfpm vendor/bin/phpstan analyse --no-progress
+
+  code-analysis-rector:
+    runs-on: ubuntu-latest
+    name: Rector
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Cache vendor
+        uses: actions/cache@v5
+        with:
+          path: vendor
+          key: vendor-php8.4-${{ hashFiles('composer.lock') }}
+          restore-keys: vendor-php8.4-
+
+      - name: Start docker compose setup and install site
+        run: |
+          docker network create frontend
+          docker compose pull --quiet
+          docker compose up --detach --wait
+          docker compose exec -T phpfpm composer install --no-interaction
+
+      - name: Check for Rector suggestions
+        run: |
+          docker compose exec -T phpfpm vendor/bin/rector process --dry-run --no-progress-bar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-54](https://github.com/itk-dev/event-database-api/pull/54)
+  Add Rector (relevant sets aligned with PHPStan), apply it across the codebase, and run it in CI
 - [PR-51](https://github.com/itk-dev/event-database-api/pull/51)
   Show the API-spec diff summary inline in the PR comment (collapsed) alongside the oasdiff review link
 - [PR-49](https://github.com/itk-dev/event-database-api/pull/49)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -165,6 +165,7 @@ tasks:
     desc: "Run code analysis"
     cmds:
       - task: code-analysis:phpstan
+      - task: code-analysis:rector
     silent: true
 
   code-analysis:phpstan:
@@ -173,6 +174,22 @@ tasks:
       - task: compose
         vars:
           COMPOSE_ARGS: exec phpfpm vendor/bin/phpstan
+    silent: true
+
+  code-analysis:rector:
+    desc: "Check for Rector suggestions (dry-run; no changes applied)"
+    cmds:
+      - task: compose
+        vars:
+          COMPOSE_ARGS: exec phpfpm vendor/bin/rector process --dry-run
+    silent: true
+
+  code-analysis:rector:apply:
+    desc: "Apply Rector changes"
+    cmds:
+      - task: compose
+        vars:
+          COMPOSE_ARGS: exec phpfpm vendor/bin/rector process
     silent: true
 
   api:test:

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpstan/phpstan-symfony": "^2.0",
         "phpunit/phpunit": "^13",
+        "rector/rector": "^2.5",
         "symfony/browser-kit": "~7.4.0",
         "symfony/css-selector": "~7.4.0",
         "symfony/maker-bundle": "^1.52",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "48d72e29a5aeb508c05569314faf8904",
+    "content-hash": "0de130ed061bef0747c1862bd4a9072a",
     "packages": [
         {
             "name": "api-platform/core",
@@ -9154,6 +9154,66 @@
                 }
             ],
             "time": "2024-06-11T12:45:25+00:00"
+        },
+        {
+            "name": "rector/rector",
+            "version": "2.5.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rectorphp/rector.git",
+                "reference": "adaa18d7cd6b3c960967cfbc98c03efb3116ac0e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rectorphp/rector/zipball/adaa18d7cd6b3c960967cfbc98c03efb3116ac0e",
+                "reference": "adaa18d7cd6b3c960967cfbc98c03efb3116ac0e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4|^8.0",
+                "phpstan/phpstan": "^2.2.2"
+            },
+            "conflict": {
+                "rector/rector-doctrine": "*",
+                "rector/rector-downgrade-php": "*",
+                "rector/rector-phpunit": "*",
+                "rector/rector-symfony": "*"
+            },
+            "suggest": {
+                "ext-dom": "To manipulate phpunit.xml via the custom-rule command"
+            },
+            "bin": [
+                "bin/rector"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Instant Upgrade and Automated Refactoring of any PHP code",
+            "homepage": "https://getrector.com/",
+            "keywords": [
+                "automation",
+                "dev",
+                "migration",
+                "refactoring"
+            ],
+            "support": {
+                "issues": "https://github.com/rectorphp/rector/issues",
+                "source": "https://github.com/rectorphp/rector/tree/2.5.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/tomasvotruba",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-06T12:41:46+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/public/spec.yaml
+++ b/public/spec.yaml
@@ -1780,9 +1780,9 @@ components:
         -
           type: object
           properties:
-            slug:
-              type: string
             name:
+              type: string
+            slug:
               type: string
     Vocabulary.jsonld:
       allOf:
@@ -1791,9 +1791,9 @@ components:
         -
           type: object
           properties:
-            slug:
-              type: string
             name:
+              type: string
+            slug:
               type: string
             description:
               type: string

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__.'/src',
+        __DIR__.'/tests',
+    ])
+    ->withCache(__DIR__.'/var/cache/rector')
+    // Coding style and import (`use`) management are owned by php-cs-fixer
+    // (PostToolUse hook / coding standards), so Rector does not touch them.
+    //
+    // Modernize to the language level declared in composer.json (PHP >= 8.3).
+    ->withPhpSets()
+    // Version-based upgrade + quality rules resolved from the installed package
+    // versions (Symfony 7.4, PHPUnit 13). No domain Doctrine here — the entities
+    // and migrations live in event-database-imports — so the Doctrine sets are
+    // intentionally omitted.
+    ->withComposerBased(symfony: true, phpunit: true)
+    // Convert any remaining annotations to native PHP attributes.
+    ->withAttributesSets(symfony: true, phpunit: true)
+    ->withPreparedSets(
+        deadCode: true,
+        codeQuality: true,
+        typeDeclarations: true,
+        privatization: true,
+        instanceOf: true,
+        earlyReturn: true,
+        symfonyCodeQuality: true,
+        phpunitCodeQuality: true,
+    );

--- a/src/Api/Dto/DailyOccurrence.php
+++ b/src/Api/Dto/DailyOccurrence.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Api\Dto;
 
 use ApiPlatform\Metadata\ApiFilter;

--- a/src/Api/Dto/Event.php
+++ b/src/Api/Dto/Event.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Api\Dto;
 
 use ApiPlatform\Metadata\ApiFilter;

--- a/src/Api/Dto/Location.php
+++ b/src/Api/Dto/Location.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Api\Dto;
 
 use ApiPlatform\Metadata\ApiFilter;

--- a/src/Api/Dto/Occurrence.php
+++ b/src/Api/Dto/Occurrence.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Api\Dto;
 
 use ApiPlatform\Metadata\ApiFilter;

--- a/src/Api/Dto/Organization.php
+++ b/src/Api/Dto/Organization.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Api\Dto;
 
 use ApiPlatform\Metadata\ApiFilter;

--- a/src/Api/Dto/Tag.php
+++ b/src/Api/Dto/Tag.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Api\Dto;
 
 use ApiPlatform\Metadata\ApiFilter;
@@ -52,14 +54,10 @@ use App\Api\State\TagRepresentationProvider;
 )]
 readonly class Tag
 {
-    #[ApiProperty(identifier: true)]
-    public string $slug;
-
-    public string $name;
-
-    public function __construct(string $name, string $slug)
-    {
-        $this->name = $name;
-        $this->slug = $slug;
+    public function __construct(
+        public string $name,
+        #[ApiProperty(identifier: true)]
+        public string $slug,
+    ) {
     }
 }

--- a/src/Api/Dto/Vocabulary.php
+++ b/src/Api/Dto/Vocabulary.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Api\Dto;
 
 use ApiPlatform\Metadata\ApiFilter;
@@ -52,22 +54,14 @@ use App\Api\State\VocabularyRepresentationProvider;
 )]
 readonly class Vocabulary
 {
-    #[ApiProperty(
-        identifier: true,
-    )]
-    public string $slug;
-
-    public string $name;
-
-    public string $description;
-
-    public array $tags;
-
-    public function __construct(string $name, string $slug, string $description, array $tags)
-    {
-        $this->name = $name;
-        $this->slug = $slug;
-        $this->description = $description;
-        $this->tags = $tags;
+    public function __construct(
+        public string $name,
+        #[ApiProperty(
+            identifier: true,
+        )]
+        public string $slug,
+        public string $description,
+        public array $tags,
+    ) {
     }
 }

--- a/src/Api/Filter/ElasticSearch/BooleanFilter.php
+++ b/src/Api/Filter/ElasticSearch/BooleanFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Api\Filter\ElasticSearch;
 
 use ApiPlatform\Elasticsearch\Filter\AbstractFilter;
@@ -16,11 +18,19 @@ final class BooleanFilter extends AbstractFilter
 
         /** @var string $property */
         foreach ($properties as $property) {
-            if (!isset($context['filters'][$property]) || '' === $context['filters'][$property] || [] === $context['filters'][$property]) {
+            if (!isset($context['filters'][$property])) {
                 // If no value or empty value is set, skip it.
                 continue;
             }
-            $terms[$property] = explode(',', $context['filters'][$property]);
+            if ('' === $context['filters'][$property]) {
+                // If no value or empty value is set, skip it.
+                continue;
+            }
+            if ([] === $context['filters'][$property]) {
+                // If no value or empty value is set, skip it.
+                continue;
+            }
+            $terms[$property] = explode(',', (string) $context['filters'][$property]);
         }
 
         return [] === $terms ? $terms : ['terms' => $terms + ['boost' => 1.0]];
@@ -33,7 +43,7 @@ final class BooleanFilter extends AbstractFilter
         }
 
         $description = [];
-        foreach ($this->properties as $filterParameterName => $value) {
+        foreach (array_keys($this->properties) as $filterParameterName) {
             $description[$filterParameterName] = [
                 'property' => $filterParameterName,
                 'type' => TypeIdentifier::BOOL->value,

--- a/src/Api/Filter/ElasticSearch/DateRangeFilter.php
+++ b/src/Api/Filter/ElasticSearch/DateRangeFilter.php
@@ -52,7 +52,7 @@ final class DateRangeFilter extends AbstractFilter
             return $ranges;
         }
 
-        foreach ($this->properties as $property => $value) {
+        foreach (array_keys($this->properties) as $property) {
             if (isset($context['filters'][$property]) && '' !== $context['filters'][$property] && [] !== $context['filters'][$property]) {
                 $ranges[] = $this->getElasticSearchQueryRanges($property, $context['filters'][$property]);
             }
@@ -94,7 +94,7 @@ final class DateRangeFilter extends AbstractFilter
             $value = $filter;
         } else {
             $operator = $this->resolveOperator((string) array_key_first($filter), $throwOnInvalid);
-            if (null === $operator) {
+            if (!$operator instanceof DateLimit) {
                 return [];
             }
             $value = array_shift($filter);
@@ -102,7 +102,7 @@ final class DateRangeFilter extends AbstractFilter
 
         switch ($operator) {
             case DateLimit::between:
-                $values = explode('..', $value);
+                $values = explode('..', (string) $value);
 
                 if (2 !== count($values)) {
                     if ($throwOnInvalid) {

--- a/src/Api/Filter/ElasticSearch/IdFilter.php
+++ b/src/Api/Filter/ElasticSearch/IdFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Api\Filter\ElasticSearch;
 
 use ApiPlatform\Elasticsearch\Filter\AbstractFilter;
@@ -16,12 +18,20 @@ final class IdFilter extends AbstractFilter
 
         /** @var string $property */
         foreach ($properties as $property) {
-            if (!isset($context['filters'][$property]) || '' === $context['filters'][$property] || [] === $context['filters'][$property]) {
+            if (!isset($context['filters'][$property])) {
+                // If no value or empty value is set, skip it.
+                continue;
+            }
+            if ('' === $context['filters'][$property]) {
+                // If no value or empty value is set, skip it.
+                continue;
+            }
+            if ([] === $context['filters'][$property]) {
                 // If no value or empty value is set, skip it.
                 continue;
             }
             $terms = [];
-            $terms[$property] = explode(',', $context['filters'][$property]);
+            $terms[$property] = explode(',', (string) $context['filters'][$property]);
             $terms['boost'] = 1.0;
             $result[]['terms'] = $terms;
         }
@@ -36,7 +46,7 @@ final class IdFilter extends AbstractFilter
         }
 
         $description = [];
-        foreach ($this->properties as $filterParameterName => $value) {
+        foreach (array_keys($this->properties) as $filterParameterName) {
             $description[$filterParameterName] = [
                 'property' => $filterParameterName,
                 'type' => TypeIdentifier::ARRAY->value,

--- a/src/Api/Filter/ElasticSearch/MatchFilter.php
+++ b/src/Api/Filter/ElasticSearch/MatchFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Api\Filter\ElasticSearch;
 
 use ApiPlatform\Elasticsearch\Filter\AbstractFilter;
@@ -34,7 +36,7 @@ final class MatchFilter extends AbstractFilter
         }
 
         $description = [];
-        foreach ($this->properties as $filterParameterName => $value) {
+        foreach (array_keys($this->properties) as $filterParameterName) {
             $description[$filterParameterName] = [
                 'property' => $filterParameterName,
                 'type' => TypeIdentifier::STRING->value,

--- a/src/Api/Filter/ElasticSearch/TagFilter.php
+++ b/src/Api/Filter/ElasticSearch/TagFilter.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Api\Filter\ElasticSearch;
 
 use ApiPlatform\Elasticsearch\Filter\AbstractFilter;
@@ -16,11 +18,19 @@ final class TagFilter extends AbstractFilter
 
         /** @var string $property */
         foreach ($properties as $property) {
-            if (!isset($context['filters'][$property]) || '' === $context['filters'][$property] || [] === $context['filters'][$property]) {
+            if (!isset($context['filters'][$property])) {
                 // If no value or empty value is set, skip it.
                 continue;
             }
-            $terms[$property] = explode(',', $context['filters'][$property]);
+            if ('' === $context['filters'][$property]) {
+                // If no value or empty value is set, skip it.
+                continue;
+            }
+            if ([] === $context['filters'][$property]) {
+                // If no value or empty value is set, skip it.
+                continue;
+            }
+            $terms[$property] = explode(',', (string) $context['filters'][$property]);
         }
 
         return [] === $terms ? $terms : ['terms' => $terms + ['boost' => 1.0]];
@@ -33,7 +43,7 @@ final class TagFilter extends AbstractFilter
         }
 
         $description = [];
-        foreach ($this->properties as $filterParameterName => $value) {
+        foreach (array_keys($this->properties) as $filterParameterName) {
             $description[$filterParameterName] = [
                 'property' => $filterParameterName,
                 'type' => TypeIdentifier::ARRAY->value,

--- a/src/Api/State/TagRepresentationProvider.php
+++ b/src/Api/State/TagRepresentationProvider.php
@@ -20,7 +20,7 @@ final class TagRepresentationProvider extends AbstractProvider implements Provid
      * @throws NotFoundExceptionInterface
      * @throws IndexException
      */
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): ?object
     {
         if ($operation instanceof CollectionOperationInterface) {
             $filters = $this->getFilters($operation, $context);

--- a/src/Api/State/VocabularyRepresentationProvider.php
+++ b/src/Api/State/VocabularyRepresentationProvider.php
@@ -20,7 +20,7 @@ final class VocabularyRepresentationProvider extends AbstractProvider implements
      * @throws NotFoundExceptionInterface
      * @throws IndexException
      */
-    public function provide(Operation $operation, array $uriVariables = [], array $context = []): object|array|null
+    public function provide(Operation $operation, array $uriVariables = [], array $context = []): ?object
     {
         if ($operation instanceof CollectionOperationInterface) {
             $filters = $this->getFilters($operation, $context);

--- a/src/Command/FixturesLoadCommand.php
+++ b/src/Command/FixturesLoadCommand.php
@@ -40,9 +40,7 @@ class FixturesLoadCommand extends Command
             InputArgument::REQUIRED,
             sprintf('Index to populate with fixture data (one of %s)', implode(', ', IndexName::values())),
             null,
-            function (CompletionInput $input): array {
-                return array_filter(IndexName::values(), fn ($item) => str_starts_with($item, $input->getCompletionValue()));
-            }
+            fn (CompletionInput $input): array => array_filter(IndexName::values(), fn ($item): bool => str_starts_with((string) $item, $input->getCompletionValue()))
         )
         ->addOption('url', null, InputOption::VALUE_OPTIONAL, 'Remote url to read fixture data from', 'https://raw.githubusercontent.com/itk-dev/event-database-imports/develop/src/DataFixtures/indexes/[index].json');
     }

--- a/src/Controller/RootController.php
+++ b/src/Controller/RootController.php
@@ -1,14 +1,15 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\Routing\Annotation\Route;
 
 class RootController extends AbstractController
 {
-    #[Route('/', name: 'app_redirect')]
+    #[\Symfony\Component\Routing\Attribute\Route('/', name: 'app_redirect')]
     public function index(): RedirectResponse
     {
         return $this->redirectToRoute('api_doc');

--- a/src/Exception/AppException.php
+++ b/src/Exception/AppException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 abstract class AppException extends \Exception

--- a/src/Exception/IndexException.php
+++ b/src/Exception/IndexException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Exception;
 
 class IndexException extends AppException

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App;
 
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;

--- a/src/Model/DateLimit.php
+++ b/src/Model/DateLimit.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model;
 
 /**

--- a/src/Model/FilterType.php
+++ b/src/Model/FilterType.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model;
 
 /**

--- a/src/Model/IndexName.php
+++ b/src/Model/IndexName.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model;
 
 enum IndexName: string

--- a/src/Model/SearchResults.php
+++ b/src/Model/SearchResults.php
@@ -1,15 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Model;
 
 /**
  * Represents the results of a search operation.
  */
-final class SearchResults
+final readonly class SearchResults
 {
     public function __construct(
-        public readonly array $hits,
-        public readonly int $total,
+        public array $hits,
+        public int $total,
     ) {
     }
 }

--- a/src/Security/ApiKeyAuthenticator.php
+++ b/src/Security/ApiKeyAuthenticator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Security;
 
 use Symfony\Component\HttpFoundation\JsonResponse;

--- a/src/Security/ApiUser.php
+++ b/src/Security/ApiUser.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Security;
 
 use Symfony\Component\Security\Core\User\UserInterface;

--- a/src/Service/ElasticSearch/ElasticIndexException.php
+++ b/src/Service/ElasticSearch/ElasticIndexException.php
@@ -40,7 +40,7 @@ class ElasticIndexException extends IndexException
             ->title()
             ->toString();
 
-        $reason = explode(': ', $message->error->root_cause[0]->reason)[0];
+        $reason = explode(': ', (string) $message->error->root_cause[0]->reason)[0];
 
         return $type.': '.$reason;
     }

--- a/src/Service/ElasticSearch/ElasticSearchPaginator.php
+++ b/src/Service/ElasticSearch/ElasticSearchPaginator.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service\ElasticSearch;
 
 use ApiPlatform\State\Pagination\PaginatorInterface;

--- a/src/Service/IndexInterface.php
+++ b/src/Service/IndexInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Service;
 
 use App\Exception\IndexException;

--- a/tests/ApiPlatform/AbstractApiTestCase.php
+++ b/tests/ApiPlatform/AbstractApiTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use ApiPlatform\Symfony\Bundle\Test\ApiTestCase;
@@ -65,7 +67,7 @@ abstract class AbstractApiTestCase extends ApiTestCase
     protected function assertMemberIds(array $expected, ResponseInterface $response, string $field = 'entityId', bool $ordered = false, string $message = ''): void
     {
         $data = $response->toArray();
-        self::assertArrayHasKey('hydra:member', $data, $message);
+        $this->assertArrayHasKey('hydra:member', $data, $message);
 
         $actual = array_map(
             static fn (array $member) => $member[$field] ?? null,
@@ -73,13 +75,13 @@ abstract class AbstractApiTestCase extends ApiTestCase
         );
 
         if ($ordered) {
-            self::assertSame($expected, $actual, $message);
+            $this->assertSame($expected, $actual, $message);
 
             return;
         }
 
         sort($expected);
         sort($actual);
-        self::assertSame($expected, $actual, $message);
+        $this->assertSame($expected, $actual, $message);
     }
 }

--- a/tests/ApiPlatform/ApiTest.php
+++ b/tests/ApiPlatform/ApiTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
-class ApiTest extends AbstractApiTestCase
+final class ApiTest extends AbstractApiTestCase
 {
     public function testRedirectToDocs(): void
     {
-        static::createClient()->request('GET', '/');
+        self::createClient()->request('GET', '/');
 
         $this->assertResponseRedirects('/api/v2/docs');
     }

--- a/tests/ApiPlatform/AuthenticationTest.php
+++ b/tests/ApiPlatform/AuthenticationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -8,7 +10,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Verify the API key auth boundary across all resources.
  */
-class AuthenticationTest extends AbstractApiTestCase
+final class AuthenticationTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/events';
 

--- a/tests/ApiPlatform/Consumer/AarhusguidenContractTest.php
+++ b/tests/ApiPlatform/Consumer/AarhusguidenContractTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform\Consumer;
 
 use App\Tests\ApiPlatform\AbstractApiTestCase;
@@ -19,7 +21,7 @@ use App\Tests\ApiPlatform\AbstractApiTestCase;
  * 12 → event 7 (tags aros/theoceanraceaarhus/ITKDev); all embedded events are
  * public (see tests/resources/daily_occurrences.json).
  */
-class AarhusguidenContractTest extends AbstractApiTestCase
+final class AarhusguidenContractTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/daily_occurrences';
 
@@ -30,8 +32,8 @@ class AarhusguidenContractTest extends AbstractApiTestCase
         $response = $this->get([
             'event.tags' => 'ITKDev',
             'event.publicAccess' => 'true',
-            'start' => static::formatDateTime('2024-01-01'),
-            'end' => static::formatDateTime('2024-12-31'),
+            'start' => self::formatDateTime('2024-01-01'),
+            'end' => self::formatDateTime('2024-12-31'),
             'page' => 1,
             'itemsPerPage' => 6,
         ]);

--- a/tests/ApiPlatform/Consumer/Os2displayContractTest.php
+++ b/tests/ApiPlatform/Consumer/Os2displayContractTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform\Consumer;
 
 use App\Tests\ApiPlatform\AbstractApiTestCase;
@@ -26,7 +28,7 @@ use Symfony\Component\HttpFoundation\Response;
  * (tags …/ITKDev); all occurrences organizer 9, location 4. Events 7 & 8 are at
  * location 4, event 9 at location 5.
  */
-class Os2displayContractTest extends AbstractApiTestCase
+final class Os2displayContractTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/occurrences';
 
@@ -36,7 +38,7 @@ class Os2displayContractTest extends AbstractApiTestCase
         $response = $this->get([
             'event.tags' => 'Koncert',
             'event.location.entityId' => 4,
-            'end' => ['gt' => static::formatDateTime('2024-12-01')],
+            'end' => ['gt' => self::formatDateTime('2024-12-01')],
             'itemsPerPage' => 20,
             'page' => 1,
         ]);
@@ -79,7 +81,7 @@ class Os2displayContractTest extends AbstractApiTestCase
         $response = $this->get([
             'title' => 'ITKDev',
             'location.entityId' => 4,
-            'occurrences.end' => ['gt' => static::formatDateTime('2024-01-01')],
+            'occurrences.end' => ['gt' => self::formatDateTime('2024-01-01')],
             'itemsPerPage' => 10,
         ], '/api/v2/events');
 

--- a/tests/ApiPlatform/Contract/CollectionContractTest.php
+++ b/tests/ApiPlatform/Contract/CollectionContractTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform\Contract;
 
 use App\Tests\ApiPlatform\AbstractApiTestCase;
@@ -15,7 +17,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * Captured against the current version; treat any diff during the upgrade as a
  * potential BC break to reconcile against the "no BC changes" rule.
  */
-class CollectionContractTest extends AbstractApiTestCase
+final class CollectionContractTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/events';
 

--- a/tests/ApiPlatform/Contract/ContentNegotiationContractTest.php
+++ b/tests/ApiPlatform/Contract/ContentNegotiationContractTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform\Contract;
 
 use App\Tests\ApiPlatform\AbstractApiTestCase;
@@ -12,7 +14,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * strong client-facing contract and a likely BC-sensitive area on upgrade
  * (default formats, negotiation behaviour).
  */
-class ContentNegotiationContractTest extends AbstractApiTestCase
+final class ContentNegotiationContractTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/events';
 

--- a/tests/ApiPlatform/Contract/ContractSchemaTest.php
+++ b/tests/ApiPlatform/Contract/ContractSchemaTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform\Contract;
 
 use App\Tests\ApiPlatform\AbstractApiTestCase;
@@ -23,16 +25,16 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * member on their item endpoint, so both collection and item members are
  * validated against the same definition; Tag/Vocabulary return true items.
  */
-class ContractSchemaTest extends AbstractApiTestCase
+final class ContractSchemaTest extends AbstractApiTestCase
 {
-    private const SCHEMA_URI = 'internal://contract.schema.json';
-    private const SCHEMA_PATH = __DIR__.'/../../schemas/contract.schema.json';
+    private const string SCHEMA_URI = 'internal://contract.schema.json';
+    private const string SCHEMA_PATH = __DIR__.'/../../schemas/contract.schema.json';
 
     #[DataProvider('collectionProvider')]
     public function testCollectionMembersMatchSchema(string $path, string $definition): void
     {
         $data = $this->get([], $path)->toArray();
-        self::assertNotEmpty($data['hydra:member'], $path.' needs at least one fixture member');
+        $this->assertNotEmpty($data['hydra:member'], $path.' needs at least one fixture member');
 
         foreach ($data['hydra:member'] as $i => $member) {
             $this->assertMatchesDefinition($member, $definition, $path.' member #'.$i);
@@ -45,8 +47,8 @@ class ContractSchemaTest extends AbstractApiTestCase
         $data = $this->get([], $path)->toArray();
 
         if ($collectionWrapped) {
-            self::assertArrayHasKey('hydra:member', $data, $path.' should return a collection wrapper (D6)');
-            self::assertNotEmpty($data['hydra:member']);
+            $this->assertArrayHasKey('hydra:member', $data, $path.' should return a collection wrapper (D6)');
+            $this->assertNotEmpty($data['hydra:member']);
             foreach ($data['hydra:member'] as $member) {
                 $this->assertMatchesDefinition($member, $definition, $path.' item member');
             }
@@ -93,19 +95,16 @@ class ContractSchemaTest extends AbstractApiTestCase
 
         $validator->validate($data, (object) ['$ref' => self::SCHEMA_URI.'#/definitions/'.$definition]);
 
-        self::assertTrue(
-            $validator->isValid(),
-            $message.' failed contract schema "'.$definition.'": '.self::formatErrors($validator->getErrors())
-        );
+        $this->assertTrue($validator->isValid(), $message.' failed contract schema "'.$definition.'": '.$this->formatErrors($validator->getErrors()));
     }
 
     /**
      * @param array<int, array{property?: string, message?: string}> $errors
      */
-    private static function formatErrors(array $errors): string
+    private function formatErrors(array $errors): string
     {
         return implode('; ', array_map(
-            static fn (array $e) => trim(($e['property'] ?? '').' '.($e['message'] ?? '')),
+            static fn (array $e): string => trim(($e['property'] ?? '').' '.($e['message'] ?? '')),
             $errors
         ));
     }

--- a/tests/ApiPlatform/Contract/DateFormatContractTest.php
+++ b/tests/ApiPlatform/Contract/DateFormatContractTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform\Contract;
 
 use App\Tests\ApiPlatform\AbstractApiTestCase;
@@ -9,11 +11,11 @@ use App\Tests\ApiPlatform\AbstractApiTestCase;
  * offset (e.g. "2024-12-08T12:30:00+01:00"), rendered in the local timezone
  * (not UTC "Z"). Date serialization is a common BC-sensitive area on upgrade.
  */
-class DateFormatContractTest extends AbstractApiTestCase
+final class DateFormatContractTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/events';
 
-    private const ISO_8601_OFFSET = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/';
+    private const string ISO_8601_OFFSET = '/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}$/';
 
     public function testOccurrenceDatesUseIso8601WithOffset(): void
     {

--- a/tests/ApiPlatform/Contract/ErrorContractTest.php
+++ b/tests/ApiPlatform/Contract/ErrorContractTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform\Contract;
 
 use App\Tests\ApiPlatform\AbstractApiTestCase;
@@ -18,7 +20,7 @@ use Symfony\Component\HttpFoundation\Response;
  * Note: the body also carries a `trace` array in the test env (debug on); that
  * is environment-dependent and intentionally NOT asserted here.
  */
-class ErrorContractTest extends AbstractApiTestCase
+final class ErrorContractTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/events';
 

--- a/tests/ApiPlatform/Contract/ItemContractTest.php
+++ b/tests/ApiPlatform/Contract/ItemContractTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform\Contract;
 
 use App\Tests\ApiPlatform\AbstractApiTestCase;
@@ -17,7 +19,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * See PR notes: this asymmetry is current behaviour, not necessarily desired —
  * the tests exist to catch it changing during the upgrade.
  */
-class ItemContractTest extends AbstractApiTestCase
+final class ItemContractTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/events';
 

--- a/tests/ApiPlatform/DailyOccurrencesFilterTest.php
+++ b/tests/ApiPlatform/DailyOccurrencesFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -10,7 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * Assertions pin the exact set of matching `entityId`s. Fixture ids mirror the
  * occurrences index: 10/11 belong to event 8, 12 to event 7.
  */
-class DailyOccurrencesFilterTest extends AbstractApiTestCase
+final class DailyOccurrencesFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/daily_occurrences';
 
@@ -35,7 +37,7 @@ class DailyOccurrencesFilterTest extends AbstractApiTestCase
 
         // DateRangeFilter on start.
         yield 'start in December 2024' => [
-            ['start[between]' => static::formatDateTime('2024-12-01').'..'.static::formatDateTime('2024-12-31')],
+            ['start[between]' => self::formatDateTime('2024-12-01').'..'.self::formatDateTime('2024-12-31')],
             [10, 12],
         ];
 

--- a/tests/ApiPlatform/DailyOccurrencesTest.php
+++ b/tests/ApiPlatform/DailyOccurrencesTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use App\Api\Dto\DailyOccurrence;
 use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
 use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
 
-class DailyOccurrencesTest extends AbstractApiTestCase
+final class DailyOccurrencesTest extends AbstractApiTestCase
 {
     use GetEntitiesTestTrait;
     use GetItemTestTrait;

--- a/tests/ApiPlatform/EventsFilterTest.php
+++ b/tests/ApiPlatform/EventsFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -11,7 +13,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * so a filter regression that returns the wrong records — not merely the wrong
  * number of them — is caught. Fixture ids: 7, 8, 9 (see tests/resources/events.json).
  */
-class EventsFilterTest extends AbstractApiTestCase
+final class EventsFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/events';
 
@@ -33,24 +35,24 @@ class EventsFilterTest extends AbstractApiTestCase
 
         // DateRangeFilter on occurrences.start.
         yield 'occurrences in 21st century' => [
-            ['occurrences.start[between]' => static::formatDateTime('2001-01-01').'..'.static::formatDateTime('2100-01-01')],
+            ['occurrences.start[between]' => self::formatDateTime('2001-01-01').'..'.self::formatDateTime('2100-01-01')],
             [7, 8, 9],
             'Every fixture event has an occurrence in the 21st century',
         ];
         yield 'occurrences in 2026' => [
-            ['occurrences.start[between]' => static::formatDateTime('2026-01-01').'..'.static::formatDateTime('2026-12-31')],
+            ['occurrences.start[between]' => self::formatDateTime('2026-01-01').'..'.self::formatDateTime('2026-12-31')],
             [9],
             'Only event 9 has an occurrence in 2026',
         ];
 
         // DateRangeFilter on updated (default operator: gte).
         yield 'updated on or after 2024' => [
-            ['updated' => static::formatDateTime('2024-01-01')],
+            ['updated' => self::formatDateTime('2024-01-01')],
             [7, 8, 9],
             'All events were updated on or after 2024-01-01',
         ];
         yield 'updated after 2100' => [
-            ['updated[gte]' => static::formatDateTime('2100-01-01')],
+            ['updated[gte]' => self::formatDateTime('2100-01-01')],
             [],
             'No events updated after 2100',
         ];
@@ -64,8 +66,8 @@ class EventsFilterTest extends AbstractApiTestCase
         // a conscious, BC-visible decision.
         yield 'F7: start/end satisfied by different occurrences' => [
             [
-                'occurrences.start[gte]' => static::formatDateTime('2024-12-01'),
-                'occurrences.end[lte]' => static::formatDateTime('2024-11-30'),
+                'occurrences.start[gte]' => self::formatDateTime('2024-12-01'),
+                'occurrences.end[lte]' => self::formatDateTime('2024-11-30'),
             ],
             [8],
             'Non-nested occurrences: event 8 matches although no single occurrence satisfies both bounds',
@@ -91,7 +93,7 @@ class EventsFilterTest extends AbstractApiTestCase
         // Combined filters.
         yield 'occurrences in 2026 AND tagged aros' => [
             [
-                'occurrences.start[between]' => static::formatDateTime('2026-01-01').'..'.static::formatDateTime('2026-12-31'),
+                'occurrences.start[between]' => self::formatDateTime('2026-01-01').'..'.self::formatDateTime('2026-12-31'),
                 'tags' => 'aros',
             ],
             [9],

--- a/tests/ApiPlatform/EventsTest.php
+++ b/tests/ApiPlatform/EventsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use App\Api\Dto\Event;
@@ -9,7 +11,7 @@ use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
 /**
  * Test that we can call the API.
  */
-class EventsTest extends AbstractApiTestCase
+final class EventsTest extends AbstractApiTestCase
 {
     use GetEntitiesTestTrait;
     use GetItemTestTrait;

--- a/tests/ApiPlatform/FilterErrorTest.php
+++ b/tests/ApiPlatform/FilterErrorTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -15,7 +17,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * non-date value passes the filter but is rejected by Elasticsearch, coming
  * back as an ElasticIndexException (also mapped to 400).
  */
-class FilterErrorTest extends AbstractApiTestCase
+final class FilterErrorTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/events';
 

--- a/tests/ApiPlatform/LocationsFilterTest.php
+++ b/tests/ApiPlatform/LocationsFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -10,7 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * Assertions pin the exact set of matching `entityId`s. Fixture ids: 4 (ITK
  * Development, postal 8000), 5 (Somewhere). See tests/resources/locations.json.
  */
-class LocationsFilterTest extends AbstractApiTestCase
+final class LocationsFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/locations';
 

--- a/tests/ApiPlatform/LocationsTest.php
+++ b/tests/ApiPlatform/LocationsTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use App\Api\Dto\Location;
 use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
 use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
 
-class LocationsTest extends AbstractApiTestCase
+final class LocationsTest extends AbstractApiTestCase
 {
     use GetEntitiesTestTrait;
     use GetItemTestTrait;

--- a/tests/ApiPlatform/OccurrencesFilterTest.php
+++ b/tests/ApiPlatform/OccurrencesFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -11,7 +13,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * 10 (start 2024-12-07, event 8), 11 (start 2024-11-08, event 8),
  * 12 (start 2024-12-08, event 7). See tests/resources/occurrences.json.
  */
-class OccurrencesFilterTest extends AbstractApiTestCase
+final class OccurrencesFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/occurrences';
 
@@ -29,19 +31,19 @@ class OccurrencesFilterTest extends AbstractApiTestCase
 
         // DateRangeFilter on start.
         yield 'start in December 2024' => [
-            ['start[between]' => static::formatDateTime('2024-12-01').'..'.static::formatDateTime('2024-12-31')],
+            ['start[between]' => self::formatDateTime('2024-12-01').'..'.self::formatDateTime('2024-12-31')],
             [10, 12],
             'Occurrences 10 and 12 start in December 2024',
         ];
         yield 'start in November 2024' => [
-            ['start[between]' => static::formatDateTime('2024-11-01').'..'.static::formatDateTime('2024-11-30')],
+            ['start[between]' => self::formatDateTime('2024-11-01').'..'.self::formatDateTime('2024-11-30')],
             [11],
             'Only occurrence 11 starts in November 2024',
         ];
 
         // DateRangeFilter on end.
         yield 'end around 2024-12-08' => [
-            ['end[between]' => static::formatDateTime('2024-12-07').'..'.static::formatDateTime('2024-12-09')],
+            ['end[between]' => self::formatDateTime('2024-12-07').'..'.self::formatDateTime('2024-12-09')],
             [10, 12],
             'Occurrences 10 and 12 end within 2024-12-07..2024-12-09',
         ];

--- a/tests/ApiPlatform/OccurrencesTest.php
+++ b/tests/ApiPlatform/OccurrencesTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use App\Api\Dto\Occurrence;
 use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
 use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
 
-class OccurrencesTest extends AbstractApiTestCase
+final class OccurrencesTest extends AbstractApiTestCase
 {
     use GetEntitiesTestTrait;
     use GetItemTestTrait;

--- a/tests/ApiPlatform/OrganizationsFilterTest.php
+++ b/tests/ApiPlatform/OrganizationsFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -10,7 +12,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * Assertions pin the exact set of matching `entityId`s. Fixture ids: 9 (ITKDev),
  * 10 (Aakb), 11 (Dokk1). See tests/resources/organizations.json.
  */
-class OrganizationsFilterTest extends AbstractApiTestCase
+final class OrganizationsFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/organizations';
 

--- a/tests/ApiPlatform/OrganizationsTest.php
+++ b/tests/ApiPlatform/OrganizationsTest.php
@@ -1,12 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use App\Api\Dto\Organization;
 use App\Tests\ApiPlatform\Trait\GetEntitiesTestTrait;
 use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
 
-class OrganizationsTest extends AbstractApiTestCase
+final class OrganizationsTest extends AbstractApiTestCase
 {
     use GetEntitiesTestTrait;
     use GetItemTestTrait;

--- a/tests/ApiPlatform/PaginationTest.php
+++ b/tests/ApiPlatform/PaginationTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -8,7 +10,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * Verify the pagination contract: itemsPerPage client override, max clamp,
  * default counts, and hydra:view navigation links.
  */
-class PaginationTest extends AbstractApiTestCase
+final class PaginationTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/events';
 

--- a/tests/ApiPlatform/SortTest.php
+++ b/tests/ApiPlatform/SortTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 /**
@@ -12,7 +14,7 @@ namespace App\Tests\ApiPlatform;
  *  - Occurrences / Daily  → start ascending
  *  - Tags/Vocab/Loc/Org   → _score, then name.keyword ascending
  */
-class SortTest extends AbstractApiTestCase
+final class SortTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/events';
 
@@ -24,7 +26,7 @@ class SortTest extends AbstractApiTestCase
         $sorted = $titles;
         sort($sorted, SORT_STRING);
 
-        self::assertSame($sorted, $titles, 'Events must be ordered by title.keyword ascending');
+        $this->assertSame($sorted, $titles, 'Events must be ordered by title.keyword ascending');
     }
 
     public function testOccurrencesAreSortedByStartAscending(): void
@@ -37,7 +39,7 @@ class SortTest extends AbstractApiTestCase
         $starts = array_column($response->toArray()['hydra:member'], 'start');
         $sorted = $starts;
         sort($sorted, SORT_STRING);
-        self::assertSame($sorted, $starts, 'start values must be ascending');
+        $this->assertSame($sorted, $starts, 'start values must be ascending');
     }
 
     public function testDailyOccurrencesAreSortedByStartAscending(): void

--- a/tests/ApiPlatform/TagsFilterTest.php
+++ b/tests/ApiPlatform/TagsFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -11,7 +13,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * the exact set of matching slugs. Fixture slugs: aros, theoceanraceaarhus,
  * koncert, for-boern, itkdev (see tests/resources/tags.json).
  */
-class TagsFilterTest extends AbstractApiTestCase
+final class TagsFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/tags';
 

--- a/tests/ApiPlatform/TagsTest.php
+++ b/tests/ApiPlatform/TagsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use App\Api\Dto\Tag;
@@ -9,7 +11,7 @@ use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
 /**
  * Test that we can call the API.
  */
-class TagsTest extends AbstractApiTestCase
+final class TagsTest extends AbstractApiTestCase
 {
     use GetEntitiesTestTrait;
     use GetItemTestTrait;

--- a/tests/ApiPlatform/VocabulariesFilterTest.php
+++ b/tests/ApiPlatform/VocabulariesFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -11,7 +13,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
  * pin the exact set of matching slugs. Fixture slugs: aarhusguiden, feeds
  * (see tests/resources/vocabularies.json).
  */
-class VocabulariesFilterTest extends AbstractApiTestCase
+final class VocabulariesFilterTest extends AbstractApiTestCase
 {
     protected static string $requestPath = '/api/v2/vocabularies';
 

--- a/tests/ApiPlatform/VocabulariesTest.php
+++ b/tests/ApiPlatform/VocabulariesTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\ApiPlatform;
 
 use App\Api\Dto\Vocabulary;
@@ -9,7 +11,7 @@ use App\Tests\ApiPlatform\Trait\GetItemTestTrait;
 /**
  * Test that we can call the API.
  */
-class VocabulariesTest extends AbstractApiTestCase
+final class VocabulariesTest extends AbstractApiTestCase
 {
     use GetEntitiesTestTrait;
     use GetItemTestTrait;

--- a/tests/Unit/Api/Filter/ElasticSearch/BooleanFilterTest.php
+++ b/tests/Unit/Api/Filter/ElasticSearch/BooleanFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit\Api\Filter\ElasticSearch;
 
 use App\Api\Filter\ElasticSearch\BooleanFilter;
@@ -10,11 +12,11 @@ use PHPUnit\Framework\TestCase;
  * Pins BooleanFilter::apply() query DSL. The value is comma-split and wrapped in
  * a single `terms` clause with a boost; an empty selection emits nothing.
  */
-class BooleanFilterTest extends TestCase
+final class BooleanFilterTest extends TestCase
 {
     use FilterFactoryMockTrait;
 
-    private const RESOURCE = 'App\Api\Dto\Event';
+    private const string RESOURCE = \App\Api\Dto\Event::class;
 
     // Goal: apply() wraps the comma-split value in a single `terms` clause with a
     // boost; unset/empty is skipped and "0" is treated as a real value.
@@ -24,7 +26,7 @@ class BooleanFilterTest extends TestCase
         [$names, $meta, $resolver] = $this->filterDependencies();
         $filter = new BooleanFilter($names, $meta, $resolver, null, ['publicAccess' => null]);
 
-        self::assertSame($expected, $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
+        $this->assertSame($expected, $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
     }
 
     public static function applyProvider(): iterable
@@ -46,8 +48,8 @@ class BooleanFilterTest extends TestCase
 
         $description = $filter->getDescription(self::RESOURCE);
 
-        self::assertArrayHasKey('publicAccess', $description);
-        self::assertSame('bool', $description['publicAccess']['type']);
-        self::assertFalse($description['publicAccess']['required']);
+        $this->assertArrayHasKey('publicAccess', $description);
+        $this->assertSame('bool', $description['publicAccess']['type']);
+        $this->assertFalse($description['publicAccess']['required']);
     }
 }

--- a/tests/Unit/Api/Filter/ElasticSearch/DateRangeFilterTest.php
+++ b/tests/Unit/Api/Filter/ElasticSearch/DateRangeFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit\Api\Filter\ElasticSearch;
 
 use ApiPlatform\Metadata\Exception\InvalidArgumentException;
@@ -16,11 +18,11 @@ use PHPUnit\Framework\TestCase;
  * to HTTP 400 via `exception_to_status` — rather than leaking a native throwable
  * as a 500. With `throwOnInvalid: false` the clause is skipped instead.
  */
-class DateRangeFilterTest extends TestCase
+final class DateRangeFilterTest extends TestCase
 {
     use FilterFactoryMockTrait;
 
-    private const RESOURCE = 'App\Api\Dto\Event';
+    private const string RESOURCE = \App\Api\Dto\Event::class;
 
     /**
      * @param array{limit: DateLimit, throwOnInvalid: bool}[] $config
@@ -42,7 +44,7 @@ class DateRangeFilterTest extends TestCase
             ['gte' => ['limit' => DateLimit::gte, 'throwOnInvalid' => true]],
         );
 
-        self::assertSame($expected, $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
+        $this->assertSame($expected, $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
     }
 
     public static function applyProvider(): iterable
@@ -109,7 +111,7 @@ class DateRangeFilterTest extends TestCase
             ['gte' => ['limit' => DateLimit::gte, 'throwOnInvalid' => false]],
         );
 
-        self::assertSame([], $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
+        $this->assertSame([], $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
     }
 
     public static function invalidInputProvider(): iterable
@@ -130,7 +132,7 @@ class DateRangeFilterTest extends TestCase
         $description = $filter->getDescription(self::RESOURCE);
 
         foreach (['updated', 'updated[between]', 'updated[gt]', 'updated[gte]', 'updated[lt]', 'updated[lte]'] as $key) {
-            self::assertArrayHasKey($key, $description, $key.' should be described');
+            $this->assertArrayHasKey($key, $description, $key.' should be described');
         }
     }
 }

--- a/tests/Unit/Api/Filter/ElasticSearch/IdFilterTest.php
+++ b/tests/Unit/Api/Filter/ElasticSearch/IdFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit\Api\Filter\ElasticSearch;
 
 use App\Api\Filter\ElasticSearch\IdFilter;
@@ -11,11 +13,11 @@ use PHPUnit\Framework\TestCase;
  * yields its own `terms` clause appended to a list, with the boost nested inside
  * the clause.
  */
-class IdFilterTest extends TestCase
+final class IdFilterTest extends TestCase
 {
     use FilterFactoryMockTrait;
 
-    private const RESOURCE = 'App\Api\Dto\Event';
+    private const string RESOURCE = \App\Api\Dto\Event::class;
 
     // Goal: apply() appends one `terms` clause per property (boost nested inside)
     // and comma-splits multi-value ids.
@@ -25,7 +27,7 @@ class IdFilterTest extends TestCase
         [$names, $meta, $resolver] = $this->filterDependencies();
         $filter = new IdFilter($names, $meta, $resolver, null, $properties);
 
-        self::assertSame($expected, $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
+        $this->assertSame($expected, $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
     }
 
     public static function applyProvider(): iterable
@@ -62,7 +64,7 @@ class IdFilterTest extends TestCase
 
         $description = $filter->getDescription(self::RESOURCE);
 
-        self::assertArrayHasKey('organizer.entityId', $description);
-        self::assertTrue($description['organizer.entityId']['is_collection']);
+        $this->assertArrayHasKey('organizer.entityId', $description);
+        $this->assertTrue($description['organizer.entityId']['is_collection']);
     }
 }

--- a/tests/Unit/Api/Filter/ElasticSearch/MatchFilterTest.php
+++ b/tests/Unit/Api/Filter/ElasticSearch/MatchFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit\Api\Filter\ElasticSearch;
 
 use App\Api\Filter\ElasticSearch\MatchFilter;
@@ -12,11 +14,11 @@ use PHPUnit\Framework\TestCase;
  * consumer-visible query contract so a change to the filter (or an API Platform
  * upgrade) is caught.
  */
-class MatchFilterTest extends TestCase
+final class MatchFilterTest extends TestCase
 {
     use FilterFactoryMockTrait;
 
-    private const RESOURCE = 'App\Api\Dto\Event';
+    private const string RESOURCE = \App\Api\Dto\Event::class;
 
     /**
      * Goal: apply() emits the exact `match` DSL — a single hit is returned bare,
@@ -30,7 +32,7 @@ class MatchFilterTest extends TestCase
         [$names, $meta, $resolver] = $this->filterDependencies();
         $filter = new MatchFilter($names, $meta, $resolver, null, $properties);
 
-        self::assertSame($expected, $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
+        $this->assertSame($expected, $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
     }
 
     public static function applyProvider(): iterable
@@ -66,9 +68,9 @@ class MatchFilterTest extends TestCase
 
         $description = $filter->getDescription(self::RESOURCE);
 
-        self::assertArrayHasKey('title', $description);
-        self::assertSame('title', $description['title']['property']);
-        self::assertSame('string', $description['title']['type']);
-        self::assertFalse($description['title']['required']);
+        $this->assertArrayHasKey('title', $description);
+        $this->assertSame('title', $description['title']['property']);
+        $this->assertSame('string', $description['title']['type']);
+        $this->assertFalse($description['title']['required']);
     }
 }

--- a/tests/Unit/Api/Filter/ElasticSearch/TagFilterTest.php
+++ b/tests/Unit/Api/Filter/ElasticSearch/TagFilterTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit\Api\Filter\ElasticSearch;
 
 use App\Api\Filter\ElasticSearch\TagFilter;
@@ -11,11 +13,11 @@ use PHPUnit\Framework\TestCase;
  * The emitted term values are verbatim (no lowercasing/normalisation): matching
  * against the production `keyword` mapping is exact and case-sensitive.
  */
-class TagFilterTest extends TestCase
+final class TagFilterTest extends TestCase
 {
     use FilterFactoryMockTrait;
 
-    private const RESOURCE = 'App\Api\Dto\Event';
+    private const string RESOURCE = \App\Api\Dto\Event::class;
 
     // Goal: apply() emits a comma-split `terms` clause with verbatim values (no
     // lowercasing), so matching the production keyword mapping stays exact.
@@ -25,7 +27,7 @@ class TagFilterTest extends TestCase
         [$names, $meta, $resolver] = $this->filterDependencies();
         $filter = new TagFilter($names, $meta, $resolver, null, ['tags' => null]);
 
-        self::assertSame($expected, $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
+        $this->assertSame($expected, $filter->apply([], self::RESOURCE, null, ['filters' => $filters]));
     }
 
     public static function applyProvider(): iterable
@@ -46,7 +48,7 @@ class TagFilterTest extends TestCase
 
         $description = $filter->getDescription(self::RESOURCE);
 
-        self::assertArrayHasKey('tags', $description);
-        self::assertTrue($description['tags']['is_collection']);
+        $this->assertArrayHasKey('tags', $description);
+        $this->assertTrue($description['tags']['is_collection']);
     }
 }

--- a/tests/Unit/Service/ElasticSearch/ElasticIndexExceptionTest.php
+++ b/tests/Unit/Service/ElasticSearch/ElasticIndexExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit\Service\ElasticSearch;
 
 use App\Service\ElasticSearch\ElasticIndexException;
@@ -10,7 +12,7 @@ use PHPUnit\Framework\TestCase;
  * A 400 is parsed from the ES error JSON into "Type: reason"; anything else
  * collapses to a generic "Bad Request".
  */
-class ElasticIndexExceptionTest extends TestCase
+final class ElasticIndexExceptionTest extends TestCase
 {
     // Goal: a 400 parse error is rendered as a readable "Parse exception: <reason>".
     public function test400ParsesElasticErrorMessage(): void
@@ -20,11 +22,8 @@ class ElasticIndexExceptionTest extends TestCase
 
         $exception = new ElasticIndexException($raw, 400);
 
-        self::assertSame(
-            'Parse exception: failed to parse date field [2004-02-12T15:19:21+0000]',
-            $exception->getMessage(),
-        );
-        self::assertSame(400, $exception->getCode());
+        $this->assertSame('Parse exception: failed to parse date field [2004-02-12T15:19:21+0000]', $exception->getMessage());
+        $this->assertSame(400, $exception->getCode());
     }
 
     // Goal: non-400 codes collapse to a generic message (no ES JSON to parse).
@@ -32,6 +31,6 @@ class ElasticIndexExceptionTest extends TestCase
     {
         $exception = new ElasticIndexException('500 Internal Server Error: something', 500);
 
-        self::assertSame('Bad Request', $exception->getMessage());
+        $this->assertSame('Bad Request', $exception->getMessage());
     }
 }

--- a/tests/Unit/Service/ElasticSearch/SearchParamsBuilderTest.php
+++ b/tests/Unit/Service/ElasticSearch/SearchParamsBuilderTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Tests\Unit\Service\ElasticSearch;
 
 use App\Model\FilterType;
@@ -13,7 +15,7 @@ use PHPUnit\Framework\TestCase;
  * the default match_all query, how filter clauses combine into `bool`/`must`,
  * and the per-index sort — without a live Elasticsearch.
  */
-class SearchParamsBuilderTest extends TestCase
+final class SearchParamsBuilderTest extends TestCase
 {
     private function noFilters(): array
     {
@@ -33,11 +35,11 @@ class SearchParamsBuilderTest extends TestCase
     {
         $params = (new SearchParamsBuilder())->buildParams(IndexName::Events->value, $this->noFilters(), 20, 5);
 
-        self::assertSame(IndexName::Events->value, $params['index']);
-        self::assertEquals(['match_all' => (object) []], $params['body']['query']);
-        self::assertSame(5, $params['body']['size']);
-        self::assertSame(20, $params['body']['from']);
-        self::assertArrayHasKey('sort', $params['body']);
+        $this->assertSame(IndexName::Events->value, $params['index']);
+        $this->assertEquals(['match_all' => (object) []], $params['body']['query']);
+        $this->assertSame(5, $params['body']['size']);
+        $this->assertSame(20, $params['body']['from']);
+        $this->assertArrayHasKey('sort', $params['body']);
     }
 
     // Goal: a single associative clause (e.g. a MatchFilter hit) is wrapped in bool/must.
@@ -50,7 +52,7 @@ class SearchParamsBuilderTest extends TestCase
             10,
         );
 
-        self::assertSame(['bool' => ['must' => [['match' => ['title' => 'x']]]]], $params['body']['query']);
+        $this->assertSame(['bool' => ['must' => [['match' => ['title' => 'x']]]]], $params['body']['query']);
     }
 
     // Goal: a list-shaped clause (e.g. IdFilter output) is flattened into must, not
@@ -64,10 +66,7 @@ class SearchParamsBuilderTest extends TestCase
             10,
         );
 
-        self::assertSame(
-            ['bool' => ['must' => [['terms' => ['organizer.entityId' => ['9'], 'boost' => 1.0]]]]],
-            $params['body']['query'],
-        );
+        $this->assertSame(['bool' => ['must' => [['terms' => ['organizer.entityId' => ['9'], 'boost' => 1.0]]]]], $params['body']['query']);
     }
 
     // Goal: multiple clauses accumulate under a single bool/must.
@@ -83,7 +82,7 @@ class SearchParamsBuilderTest extends TestCase
             10,
         );
 
-        self::assertSame([
+        $this->assertSame([
             ['match' => ['title' => 'x']],
             ['terms' => ['tags' => ['aros'], 'boost' => 1.0]],
         ], $params['body']['query']['bool']['must']);
@@ -95,7 +94,7 @@ class SearchParamsBuilderTest extends TestCase
     {
         $params = (new SearchParamsBuilder())->buildParams($index, $this->noFilters(), 0, 10);
 
-        self::assertSame($expectedSort, $params['body']['sort']);
+        $this->assertSame($expectedSort, $params['body']['sort']);
     }
 
     public static function sortProvider(): iterable

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Symfony\Component\Dotenv\Dotenv;
 
 require dirname(__DIR__).'/vendor/autoload.php';


### PR DESCRIPTION
Mirrors event-database-imports #105 — adds Rector with the relevant sets aligned to our PHPStan level-8 + strict setup, applies it across the codebase, and (unlike importers) wires it into CI.

## Changes

- Add `rector/rector: ^2.5` (dev) and `rector.php`:
  - `withPhpSets()`, `withComposerBased(symfony: true, phpunit: true)`, `withAttributesSets(symfony: true, phpunit: true)`.
  - Prepared sets: deadCode, codeQuality, typeDeclarations, privatization, instanceOf, earlyReturn, symfonyCodeQuality, phpunitCodeQuality.
  - **Doctrine and Carbon sets omitted** — no domain Doctrine here (entities live in `event-database-imports`), Carbon unused. Coding style/imports stay owned by php-cs-fixer.
- Apply Rector across `src/` and `tests/` (64 files): `declare(strict_types=1)`, constructor promotion, typed constants, `readonly` classes, arrow-fn return types, `self::` → `$this->` in tests, `final` test classes, etc.
- `task code-analysis` now runs PHPStan **and** Rector; add `code-analysis:rector` (dry-run) and `code-analysis:rector:apply`.
- Add a **Rector** job to the Code Review workflow (`rector process --dry-run`) — the CI step importers omitted.

## Validation

- Full suite: **252 tests** green.
- **PHPStan level 8 + strict + baseline**: no errors.
- php-cs-fixer + composer-normalize clean; `rector process --dry-run` is idempotent (clean after apply).
- Unlike importers, **no rule needed skipping** — this codebase tolerated the full set (including `FlipTypeControlToUseExclusiveTypeRector`, which importers had to skip).

## Note

The new **Rector** check is not yet a required status check on `develop`. Say the word and I'll add it to branch protection alongside `PHPStan static analysis`.