### PR TITLE
Self-heal the "API spec up to date" PR comment

### DIFF
--- a/.github/workflows/api-spec.yml
+++ b/.github/workflows/api-spec.yml
@@ -50,15 +50,53 @@ jobs:
         continue-on-error: true
         run: git diff --diff-filter=ACMRT --exit-code public/spec.yaml
 
-      - name: Comment PR
-        if: steps.git-diff-spec.outcome == 'failure'
+      - name: Find previous export comment
+        id: prev-export-comment
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          echo '## 🛑 Exported API specification file not up to date' > var/comment.md
-          echo '' >> var/comment.md
-          echo 'Please run `task api:spec:export` to export the API specification. Then commit and push the changes.' >> var/comment.md
-          gh pr comment ${{ github.event.pull_request.number }} --body-file var/comment.md --create-if-none --edit-last
+          id=$(gh api \
+            "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+            --paginate \
+            --jq '.[] | select(.body | startswith("<!-- api-spec-export -->")) | .id' \
+            | tail -n1)
+          echo "id=${id:-}" >> "$GITHUB_OUTPUT"
+
+      - name: Comment PR - spec out of date
+        if: steps.git-diff-spec.outcome == 'failure'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREV_ID: ${{ steps.prev-export-comment.outputs.id }}
+        run: |
+          {
+            echo "<!-- api-spec-export -->"
+            echo "## 🛑 Exported API specification file not up to date"
+            echo ""
+            echo "Run \`task api:spec:export\` to export the API specification, then commit and push the changes."
+          } > comment.md
+          if [ -n "$PREV_ID" ]; then
+            jq -Rs '{body: .}' < comment.md \
+              | gh api "repos/${{ github.repository }}/issues/comments/$PREV_ID" --method PATCH --input -
+          else
+            gh pr comment ${{ github.event.pull_request.number }} --body-file comment.md
+          fi
+
+      # Self-heal: once the committed spec matches the export again, edit the
+      # previous 🛑 comment to ✅ instead of leaving a stale failure comment.
+      - name: Mark export comment resolved (when up to date)
+        if: steps.git-diff-spec.outcome == 'success' && steps.prev-export-comment.outputs.id != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PREV_ID: ${{ steps.prev-export-comment.outputs.id }}
+        run: |
+          {
+            echo "<!-- api-spec-export -->"
+            echo "## ✅ Exported API specification is up to date"
+            echo ""
+            echo "_Resolved — the committed \`public/spec.yaml\` matches the export._"
+          } > comment.md
+          jq -Rs '{body: .}' < comment.md \
+            | gh api "repos/${{ github.repository }}/issues/comments/$PREV_ID" --method PATCH --input -
 
       - name: Fail job api spec is not up to date
         if: steps.git-diff-spec.outcome == 'failure'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-55](https://github.com/itk-dev/event-database-api/pull/55)
+  Self-heal the API-spec "up to date" PR comment (resolve to ✅ once the spec matches, no stale 🛑)
 - [PR-53](https://github.com/itk-dev/event-database-api/pull/53)
   Compare effective schemas in the oasdiff gate (flatten-allof) so allOf/$ref restructures are not miscounted
 - [PR-52](https://github.com/itk-dev/event-database-api/pull/52)


### PR DESCRIPTION
Fixes the stale-comment gap that left a 🛑 "spec not up to date" comment on a PR even after the spec was re-exported.

## Changes

- The `api-spec` job's comment now carries a sticky marker (`<!-- api-spec-export -->`) and follows the same find-previous → upsert → resolve pattern the breaking-changes comment already uses:
  - **drift** → post/patch the 🛑 "not up to date" comment;
  - **up to date** → edit that comment to ✅ "resolved" (instead of leaving the stale 🛑).
- Drops the `var/comment.md` path (uses `comment.md` like the other job) and the `--edit-last` heuristic in favour of the explicit marker lookup.

## Why

The job posted the 🛑 comment on failure but had no clear-on-success step, so once a contributor fixed the spec the failure comment lingered and misled reviewers (as just happened on #54 after the Rector-driven re-export). The breaking-changes comment already self-heals; this brings the "up to date" comment in line.