### PR TITLE
Scope CI image pulls to each job's real dependencies

### DIFF
--- a/.github/workflows/api-spec.yml
+++ b/.github/workflows/api-spec.yml
@@ -34,16 +34,17 @@ jobs:
           key: vendor-php8.4-${{ hashFiles('composer.lock') }}
           restore-keys: vendor-php8.4-
 
-      # https://taskfile.dev/installation/#github-actions
-      - uses: go-task/setup-task@v2
-
-      - run: |
+      - name: Install dependencies
+        run: |
           docker network create frontend
-          task --yes site:update
+          # The spec export only needs PHP — pull phpfpm alone and run it as a
+          # one-off (--no-deps skips mariadb/rabbit), not the whole stack.
+          docker compose pull --quiet phpfpm
+          docker compose run --rm --no-deps phpfpm composer install --no-interaction
 
       - name: Export API specification
         run: |
-          task --yes api:spec:export
+          docker compose run --rm --no-deps phpfpm bin/console api:openapi:export --yaml --output=public/spec.yaml --no-interaction
 
       - name: Check for changes in specification
         id: git-diff-spec

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,8 +23,10 @@ jobs:
       - name: Start docker compose setup and install site
         run: |
           docker network create frontend
-          docker compose pull --quiet
-          docker compose up --detach --wait
+          # API tests need PHP + Elasticsearch only (not mariadb/rabbit/nginx/mail);
+          # --no-deps keeps phpfpm's mariadb/rabbit dependencies from starting.
+          docker compose pull --quiet phpfpm elasticsearch
+          docker compose up --detach --wait --no-deps phpfpm elasticsearch
           docker compose exec -T phpfpm composer install --no-interaction
 
       - name: Load test fixtures
@@ -58,16 +60,16 @@ jobs:
           key: vendor-php8.4-${{ hashFiles('composer.lock') }}
           restore-keys: vendor-php8.4-
 
-      - name: Start docker compose setup and install site
+      - name: Install dependencies
         run: |
           docker network create frontend
-          docker compose pull --quiet
-          docker compose up --detach --wait
-          docker compose exec -T phpfpm composer install --no-interaction
+          # PHPStan only needs PHP — pull phpfpm and run it as a one-off (--no-deps).
+          docker compose pull --quiet phpfpm
+          docker compose run --rm --no-deps phpfpm composer install --no-interaction
 
       - name: Run code analysis
         run: |
-          docker compose exec -T phpfpm vendor/bin/phpstan analyse --no-progress
+          docker compose run --rm --no-deps phpfpm vendor/bin/phpstan analyse --no-progress
 
   code-analysis-rector:
     runs-on: ubuntu-latest
@@ -82,13 +84,13 @@ jobs:
           key: vendor-php8.4-${{ hashFiles('composer.lock') }}
           restore-keys: vendor-php8.4-
 
-      - name: Start docker compose setup and install site
+      - name: Install dependencies
         run: |
           docker network create frontend
-          docker compose pull --quiet
-          docker compose up --detach --wait
-          docker compose exec -T phpfpm composer install --no-interaction
+          # Rector only needs PHP — pull phpfpm and run it as a one-off (--no-deps).
+          docker compose pull --quiet phpfpm
+          docker compose run --rm --no-deps phpfpm composer install --no-interaction
 
       - name: Check for Rector suggestions
         run: |
-          docker compose exec -T phpfpm vendor/bin/rector process --dry-run --no-progress-bar
+          docker compose run --rm --no-deps phpfpm vendor/bin/rector process --dry-run --no-progress-bar

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-56](https://github.com/itk-dev/event-database-api/pull/56)
+  Scope CI image pulls to each job's real dependencies (phpfpm, or phpfpm + elasticsearch) instead of the whole stack
 - [PR-54](https://github.com/itk-dev/event-database-api/pull/54)
   Add Rector (relevant sets aligned with PHPStan), apply it across the codebase, and run it in CI
 - [PR-53](https://github.com/itk-dev/event-database-api/pull/53)


### PR DESCRIPTION
Every workflow job pulled and started the whole compose stack (mariadb, phpfpm, nginx, mail, rabbit, elasticsearch, markdownlint, prettier) even when it only needed PHP. This scopes each job to what it actually uses.

## Changes

- **api-spec export** — was `task site:update` (pull/up everything). Now pulls only `phpfpm` and runs the export as a one-off `docker compose run --rm --no-deps phpfpm …` (drops the Task setup).
- **PHPStan** and **Rector** (pr.yaml) — pull only `phpfpm`, run via `run --rm --no-deps` (matches the templated composer/php/twig workflows; no lingering container, no healthcheck wait).
- **API test** (pr.yaml) — pulls only `phpfpm elasticsearch` and starts them with `up --wait --no-deps` (Elasticsearch must be a running service the tests connect to).

`--no-deps` stops `phpfpm`'s `mariadb`/`rabbit` `depends_on` from starting the rest of the stack.

## Validation

- Full suite (254 tests) passes with **mariadb and rabbit stopped** → API test needs only phpfpm + elasticsearch.
- Tests reference no Doctrine/DB and `ApiTestCase` uses the in-process kernel (not real HTTP), so **nginx** and **mariadb** aren't needed.
- `docker compose run --rm --no-deps phpfpm …` verified locally; YAML prettier-clean.

## Audit note

The templated workflows (`composer`, `php`, `twig` → `run --rm phpfpm`; `markdown` → `markdownlint`; `yaml` → `prettier`) and `build_release` (`run --rm phpfpm`) were already scoped; `changelog` and `index-mapping-drift` use no containers. Only the repo-owned `api-spec.yml` and `pr.yaml` over-pulled.