### PR TITLE
Refresh CLAUDE.md and agent docs for current tooling/versions

### DIFF
--- a/.claude/agents/pr-readiness.md
+++ b/.claude/agents/pr-readiness.md
@@ -16,13 +16,14 @@ JS/CSS to lint). Stop early if a critical check fails.
 4. **Twig coding standards**: `task coding-standards:twig:check`
 5. **YAML coding standards**: `task coding-standards:yaml:check`
 6. **Markdown coding standards**: `task coding-standards:markdown:check`
-7. **PHPStan (level 6)**: `task code-analysis:phpstan`
+7. **PHPStan (level 8)**: `task code-analysis:phpstan`
 8. **Rector (dry-run)**: `task code-analysis:rector` — the `Rector` gate fails on any suggested change; run `task code-analysis:rector:apply` to fix.
 9. **Test fixtures + API tests**: `task fixtures:load:test --yes && task api:test`. Tests hit a real Elasticsearch, so fixtures must be loaded first. If the load fails with "No alive nodes", run `docker compose up --detach --wait` and retry — see the `reload-fixtures` agent for the full recovery dance.
 10. **API spec up to date** (mirrors `.github/workflows/api-spec.yml`):
 
 - `task api:spec:export`
 - `git diff --exit-code public/spec.yaml` — must be clean.
+
 1. **CHANGELOG updated**: `git diff develop -- CHANGELOG.md` should show at least one entry under `## [Unreleased]`.
 
 ## Output

--- a/.claude/agents/reload-fixtures.md
+++ b/.claude/agents/reload-fixtures.md
@@ -22,4 +22,4 @@ Two flavours of fixtures exist (see `src/Model/IndexName.php` for the seven inde
    - Poll the cluster health endpoint until it returns HTTP 200:
      `docker compose exec elasticsearch curl 'http://localhost:9200/_cluster/health?wait_for_status=yellow&timeout=5s' --verbose`
    - Re-run the fixture load command.
-5. Report which indices were loaded and any non-fatal warnings (the Taskfile sets `ignore_error: true` because some fixtures emit a benign `Warning: Undefined array key "entityId"`).
+5. Report which indices were loaded and any non-fatal warnings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-59](https://github.com/itk-dev/event-database-api/pull/59)
+  Refresh CLAUDE.md/agent docs for current tooling (API Platform 4.3, php8.4 image, PHPStan level 8, test layout)
 - [PR-58](https://github.com/itk-dev/event-database-api/pull/58)
   Update dependencies in-constraint (Symfony 7.4.14 patch train, phpunit/php-cs-fixer/phpstan-symfony/flex)
 - [PR-57](https://github.com/itk-dev/event-database-api/pull/57)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,8 +10,8 @@ API platform front-end for the Danish event database used by the municipality of
 `docker-compose.yml` is part of the standard ITK Dev Symfony image but is **not used for domain data** (the
 `migrations/` and `src/Entity/` directories are empty).
 
-Stack: PHP 8.3+, Symfony 7.4, API Platform 4.1, Elasticsearch 8.x. Runs entirely in Docker via
-`itkdev/php8.3-fpm` + nginx.
+Stack: PHP 8.3+, Symfony 7.4, API Platform 4.3, Elasticsearch 8.x. Runs entirely in Docker via
+`itkdev/php8.4-fpm` + nginx.
 
 ## Common commands
 
@@ -46,14 +46,21 @@ The test harness creates each index with a **production-parity mapping** (`dynam
 `tests/resources/mappings/<index>.json` — a hand-kept copy of the importer's `src/Model/Indexing/Mappings/`.
 `FixtureLoader::createIndex()` fails loudly if a mapping is missing, so the filter tests exercise real field
 semantics (`keyword` = exact/case-sensitive; `text` = tokenised) rather than Elasticsearch dynamic-mapping
-artefacts. When the importer changes a mapping, update the matching file here (the `Stop` hook warns on drift).
+artefacts. When the importer changes a mapping, update the matching file here — the `Stop` hook warns locally,
+and the `index-mapping-drift` CI job fails if these diverge from the importer's committed `resources/mappings`
+export (`.github/workflows/index-mapping-drift.yaml`).
+
+The suite is split into `tests/ApiPlatform/Contract/` (JSON-LD envelope + deep payload schemas via
+`ContractSchemaTest`, `tests/schemas/`), `tests/ApiPlatform/Consumer/` (per-consumer contracts —
+`AarhusguidenContractTest`, `Os2displayContractTest`), the per-resource `*Test`/`*FilterTest` (behavioural), and
+`tests/Unit/` (filter DSL + `SearchParamsBuilder`, runnable with Elasticsearch stopped).
 
 ### Lint / static analysis
 
 ```shell
 task coding-standards:check              # markdown + php-cs-fixer + twig-cs-fixer + prettier (yaml)
 task coding-standards:apply              # auto-fix all of the above
-task code-analysis                       # PHPStan, level 6
+task code-analysis                       # PHPStan (level 8) + Rector
 ```
 
 CI (GitHub Actions `pr.yaml`) runs all of these — run them locally before opening a PR.


### PR DESCRIPTION
Audited README, CLAUDE.md, all `.claude/agents/*`, `.claude/skills/**`, and `.claude/settings.json` against `composer.json`, `phpstan.dist.neon`, `phpunit.dist.xml`, `Taskfile.yml`, the workflows, and the `src`/`tests` layout. Fixes the stale bits.

## Corrected (were wrong)

- **CLAUDE.md** — Stack line: API Platform **4.1 → 4.3**; image **`itkdev/php8.3-fpm` → `itkdev/php8.4-fpm`**.
- **CLAUDE.md** + **`.claude/agents/pr-readiness.md`** — PHPStan **level 6 → 8** (the `code-analysis` comment also now notes Rector).
- **`.claude/agents/reload-fixtures.md`** — dropped the stale `ignore_error: true` fixtures rationale (removed from the Taskfile in the mappings PR).

## Filled gaps (testing/architecture, newly true)

- **CLAUDE.md** — the ES index contract is now **CI-enforced** (`index-mapping-drift.yaml` vs the importer's committed `resources/mappings` export), not only the local `Stop` hook.
- **CLAUDE.md** — documented the test-suite layout that has grown since it was written: `Contract/` (+ `ContractSchemaTest`, `tests/schemas/`), `Consumer/` (aarhusguiden, os2display), the per-resource behavioural tests, and `tests/Unit/`.

## Checked and accurate (no change)

PHP floor `>=8.3`, the six filters, `failOnDeprecation/Notice/Warning`, the PostToolUse Rector hook (#57), the skills (`changelog-entry`, `new-resource`, `update-api-spec`), `filter-provider-reviewer`, and `.claude/settings.json` hook commands. README pins no versions, so nothing stale there.