### PR TITLE
chore: upgrade Elasticsearch to 8.19.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-60](https://github.com/itk-dev/event-database-api/pull/60)
+  Upgrade Elasticsearch to 8.19.18 (dev image) and the `elasticsearch/elasticsearch` client constraint to `^8.19`
 - [PR-59](https://github.com/itk-dev/event-database-api/pull/59)
   Refresh CLAUDE.md/agent docs for current tooling (API Platform 4.3, php8.4 image, PHPStan level 8, test layout)
 - [PR-58](https://github.com/itk-dev/event-database-api/pull/58)

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "ext-ctype": "*",
         "ext-iconv": "*",
         "api-platform/core": "~4.3.0",
-        "elasticsearch/elasticsearch": "^8.13",
+        "elasticsearch/elasticsearch": "^8.19",
         "nelmio/cors-bundle": "^2.4",
         "phpdocumentor/reflection-docblock": "^5.6",
         "phpstan/phpdoc-parser": "^2.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0de130ed061bef0747c1862bd4a9072a",
+    "content-hash": "747cb423309e517227c3648b1003fc5a",
     "packages": [
         {
             "name": "api-platform/core",

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -33,7 +33,7 @@ services:
       - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${COMPOSE_DOMAIN}`) && (PathPrefix(`${APP_PATH_PREFIX}`) || PathPrefix(`/_wdt`) || PathPrefix(`/_profiler`))"
 
   elasticsearch:
-    image: elasticsearch:8.13.0
+    image: elasticsearch:8.19.18
     networks:
       - app
       - frontend


### PR DESCRIPTION
Bump Elasticsearch `8.13.0` → `8.19.18` (latest 8.x) and tighten the `elasticsearch/elasticsearch` client constraint `^8.13` → `^8.19`.

## Changes
- `docker-compose.override.yml`: dev ES image → `8.19.18`
- `composer.json`: client `^8.19` (lock already at 8.19.0; only the content-hash changes)

## Coordinated upgrade
Part of an Elasticsearch 8.19 bump across the three repos sharing the cluster:
- event-database-services — cluster image ([PR #2](https://github.com/itk-dev/event-database-services/pull/2))
- event-database-imports — override image + client ([PR #110](https://github.com/itk-dev/event-database-imports/pull/110))
- **event-database-api — this PR**

Within-major (8.13 → 8.19) is backward-compatible per Elastic's support policy. The API only reads from the shared cluster; deploy the cluster (services) first/with the clients.

PHPStan is clean; the API test suite runs in CI.