### PR TITLE
Fix api-spec no-change detection for oasdiff v0.1.x

### DIFF
--- a/.github/workflows/api-spec.yml
+++ b/.github/workflows/api-spec.yml
@@ -163,7 +163,9 @@ jobs:
       - name: Determine whether the spec changed
         id: changes
         run: |
-          if [ -s changelog.md ] && ! grep -qi 'no changes' changelog.md; then
+          # oasdiff writes "No changelog changes" (v0.1.x) / "No changes" (older)
+          # when the spec is unchanged; treat either as no change.
+          if [ -s changelog.md ] && ! grep -qiE 'no (changelog )?changes' changelog.md; then
             echo "has_changes=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_changes=false" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ See [keep a changelog] for information about writing changes to this log.
 
 ## [Unreleased]
 
+- [PR-61](https://github.com/itk-dev/event-database-api/pull/61)
+  Fix the API-spec workflow's no-change detection for oasdiff v0.1.x ("No changelog changes" wording)
 - [PR-60](https://github.com/itk-dev/event-database-api/pull/60)
   Upgrade Elasticsearch to 8.19.18 (dev image) and the `elasticsearch/elasticsearch` client constraint to `^8.19`
 - [PR-59](https://github.com/itk-dev/event-database-api/pull/59)


### PR DESCRIPTION
Fixes the misleading "⚠️ API specification — non-breaking changes" comment on PRs that don't touch the spec (e.g. #60, the Elasticsearch bump — the comment body literally read "No changelog changes").

## Root cause

The `detect-breaking-changes` job's "Determine whether the spec changed" step:

```bash
if [ -s changelog.md ] && ! grep -qi 'no changes' changelog.md; then has_changes=true
```

oasdiff **v0.1.x** (adopted in #49) emits **"No changelog changes"** for an unchanged spec. The grep looks for the substring `no changes`, which doesn't occur in "No **changelog** changes", so `has_changes` was always `true` → the ⚠️ comment fired with an empty/no-change body. (The pre-v0.1 wording was "No changes", which matched — so this regressed with the version bump, undetected until a no-spec-change PR ran.)

## Fix

Match both wordings: `grep -qiE 'no (changelog )?changes'`. Verified it flags "No changelog changes" and "No changes" as no-change, while a real changelog (e.g. `### GET /api/v2/events\n- added …`) still counts as a change.

With this, a no-spec-change PR takes the no-change path: the ⚠️ comment no longer posts, and any prior comment self-heals to ✅ (via #55's resolve step).